### PR TITLE
Split model classes into separate submodule

### DIFF
--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -23,7 +23,8 @@ import json
 
 from commissaire.resource import Resource
 from commissaire.jobs import POOLS, clusterexec
-from commissaire.handlers.models import *
+from commissaire.handlers.models import (
+    Cluster, Clusters, ClusterRestart, ClusterUpgrade, Host)
 
 
 class ClustersResource(Resource):

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -21,63 +21,9 @@ import falcon
 import etcd
 import json
 
-from commissaire.model import Model
 from commissaire.resource import Resource
-from commissaire.handlers.hosts import Host
 from commissaire.jobs import POOLS, clusterexec
-
-
-class Cluster(Model):
-    """
-    Representation of a Cluster.
-    """
-    _json_type = dict
-    _attributes = ('status',)
-
-    def __init__(self, **kwargs):
-        Model.__init__(self, **kwargs)
-        # Hosts is always calculated, not stored in etcd.
-        self.hosts = {'total': 0,
-                      'available': 0,
-                      'unavailable': 0}
-
-    # FIXME Generalize and move to Model?
-    def to_json_with_hosts(self):
-        data = {}
-        for key in self._attributes:
-            data[key] = getattr(self, key)
-        data['hosts'] = self.hosts
-        return json.dumps(data)
-
-
-class ClusterRestart(Model):
-    """
-    Representation of a Cluster restart operation.
-    """
-
-    _json_type = dict
-    _attributes = (
-        'status', 'restarted', 'in_process',
-        'started_at', 'finished_at')
-
-
-class ClusterUpgrade(Model):
-    """
-    Representation of a Cluster upgrade operation.
-    """
-
-    _json_type = dict
-    _attributes = (
-        'status', 'upgrade_to', 'upgraded', 'in_process',
-        'started_at', 'finished_at')
-
-
-class Clusters(Model):
-    """
-    Representation of a group of one or more Clusters.
-    """
-    _json_type = list
-    _attributes = ('clusters',)
+from commissaire.handlers.models import *
 
 
 class ClustersResource(Resource):

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -23,7 +23,7 @@ import json
 
 from commissaire.queues import INVESTIGATE_QUEUE
 from commissaire.resource import Resource
-from commissaire.handlers.models import *
+from commissaire.handlers.models import Cluster, Host, Hosts
 
 
 class HostsResource(Resource):

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -21,28 +21,9 @@ import falcon
 import etcd
 import json
 
-from commissaire.model import Model
 from commissaire.queues import INVESTIGATE_QUEUE
 from commissaire.resource import Resource
-
-
-class Host(Model):
-    """
-    Representation of a Host.
-    """
-    _json_type = dict
-    _attributes = (
-        'address', 'status', 'os', 'cpus', 'memory',
-        'space', 'last_check', 'ssh_priv_key')
-    _hidden_attributes = ('ssh_priv_key', )
-
-
-class Hosts(Model):
-    """
-    Representation of a group of one or more Hosts.
-    """
-    _json_type = list
-    _attributes = ('hosts', )
+from commissaire.handlers.models import *
 
 
 class HostsResource(Resource):

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Models for handlers.
+"""
+
+import json
+
+from commissaire.model import Model
+
+
+class Cluster(Model):
+    """
+    Representation of a Cluster.
+    """
+    _json_type = dict
+    _attributes = ('status',)
+
+    def __init__(self, **kwargs):
+        Model.__init__(self, **kwargs)
+        # Hosts is always calculated, not stored in etcd.
+        self.hosts = {'total': 0,
+                      'available': 0,
+                      'unavailable': 0}
+
+    # FIXME Generalize and move to Model?
+    def to_json_with_hosts(self):
+        data = {}
+        for key in self._attributes:
+            data[key] = getattr(self, key)
+        data['hosts'] = self.hosts
+        return json.dumps(data)
+
+
+class ClusterRestart(Model):
+    """
+    Representation of a Cluster restart operation.
+    """
+
+    _json_type = dict
+    _attributes = (
+        'status', 'restarted', 'in_process',
+        'started_at', 'finished_at')
+
+
+class ClusterUpgrade(Model):
+    """
+    Representation of a Cluster upgrade operation.
+    """
+
+    _json_type = dict
+    _attributes = (
+        'status', 'upgrade_to', 'upgraded', 'in_process',
+        'started_at', 'finished_at')
+
+
+class Clusters(Model):
+    """
+    Representation of a group of one or more Clusters.
+    """
+    _json_type = list
+    _attributes = ('clusters',)
+
+
+class Host(Model):
+    """
+    Representation of a Host.
+    """
+    _json_type = dict
+    _attributes = (
+        'address', 'status', 'os', 'cpus', 'memory',
+        'space', 'last_check', 'ssh_priv_key')
+    _hidden_attributes = ('ssh_priv_key', )
+
+
+class Hosts(Model):
+    """
+    Representation of a group of one or more Hosts.
+    """
+    _json_type = list
+    _attributes = ('hosts', )
+
+
+class Status(Model):
+    """
+    Representation of a Host.
+    """
+    _json_type = dict
+    _attributes = (
+        'etcd', 'investigator', 'clusterexecpool')

--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -19,18 +19,9 @@ Status handlers.
 import falcon
 import etcd
 
-from commissaire.model import Model
 from commissaire.jobs import POOLS
 from commissaire.resource import Resource
-
-
-class Status(Model):
-    """
-    Representation of a Host.
-    """
-    _json_type = dict
-    _attributes = (
-        'etcd', 'investigator', 'clusterexecpool')
+from commissaire.handlers.models import *
 
 
 class StatusResource(Resource):

--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -21,7 +21,7 @@ import etcd
 
 from commissaire.jobs import POOLS
 from commissaire.resource import Resource
-from commissaire.handlers.models import *
+from commissaire.handlers.models import Status
 
 
 class StatusResource(Resource):


### PR DESCRIPTION
Got myself into a circular dependency situation with some work I'm doing, where `clusters.py` needed models from `host.py` and `host.py` needed models from `cluster.py`.

Python no likie.

The `Model` classes are small and standalone, so I created a `models.py` and lumped them all together there so the `Resource` classes can import them without conflict.

I know there's less drastic workarounds but this seems cleaner for the long term.

What do you think?