### PR TITLE
Extend cluster endpoint to manage host membership

### DIFF
--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -42,6 +42,75 @@ No body.
 
 
 
+Cluster Members
+---------------
+**Endpoint**: /api/v0/cluster/{NAME}/hosts
+
+GET
+```
+Retrieve the host list for a cluster.
+
+.. code-block:: javascript
+
+   [
+       host_address,...
+   ]
+
+Example
+~~~~~~~
+
+.. code-block:: javascript
+
+   [
+       "192.168.100.50",
+       "192.168.100.51"
+   ]
+
+PUT
+```
+Replace the host list for a cluster.  The "old" list must match the
+current host list.
+
+.. code-block:: javascript
+
+   {
+       "old": [host_address,...]
+       "new": [host_address,...]
+   }
+
+Example
+~~~~~~~
+
+.. code-block:: javascript
+
+   {
+       "old": ["192.168.100.50"],
+       "new": ["192.168.100.50", "192.168.100.51"]
+   }
+
+
+Cluster Members (Individual)
+----------------------------
+**Endpoint**: /api/v0/cluster/{NAME}/hosts/{IP}
+
+GET
+```
+Membership test.  Returns 200 if host {IP} is in cluster, else 404.
+
+PUT
+```
+Adds host {IP} to cluster. (Idempotent)
+
+No body.
+
+DELETE
+``````
+Removes host {IP} from cluster. (Idempotent)
+
+No body.
+
+
+
 Cluster Operations: Upgrade
 ---------------------------
 **Endpoint**: /api/v0/cluster/{NAME}/upgrade

--- a/example/rest_calls.py
+++ b/example/rest_calls.py
@@ -142,22 +142,115 @@ r = requests.put(
 print(r.json())
 expected_status(r, 201)
 
-print("=> Examining Cluster 'honeynut' (All Hosts Implicitly Added)")
+print("=> Examining Cluster 'honeynut' (No Hosts)")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut', auth=AUTH)
+print(r.json())
+expect = {'status': 'ok', 'hosts': {'total': 0, 'available': 0, 'unavailable': 0}}
+expected_json(r.json(), expect) and expected_status(r, 200)
+
+print("=> Verify Host List for Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH)
+print(r.json())
+expected_json(r.json(), []) and expected_status(r, 200)
+
+print("=> Verify Host 10.2.0.2 Not In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 404)
+
+print("=> Adding Host 10.2.0.2 to Cluster 'honeynut'")
+r = requests.put(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 200)
+
+print("=> Examining Cluster 'honeynut' (1 Host)")
 r = requests.get(SERVER + '/api/v0/cluster/honeynut', auth=AUTH)
 print(r.json())
 expect = {'status': 'ok', 'hosts': {'total': 1, 'available': 0, 'unavailable': 1}}
 expected_json(r.json(), expect) and expected_status(r, 200)
 
-# FIXME: Verify membership of host in cluster,
-#        once clusters have explicit members.
+print("=> Verify Host List for Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH)
+print(r.json())
+expected_json(r.json(), ['10.2.0.2']) and expected_status(r, 200)
 
-print("=> Deleting Host 10.2.0.2")
+print("=> Verify Host 10.2.0.2 In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 200)
+
+print("=> Deleting Host 10.2.0.2 from Cluster 'honeynut'")
+r = requests.delete(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 200)
+
+print("=> Examining Cluster 'honeynut' (No Hosts)")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut', auth=AUTH)
+print(r.json())
+expect = {'status': 'ok', 'hosts': {'total': 0, 'available': 0, 'unavailable': 0}}
+expected_json(r.json(), expect) and expected_status(r, 200)
+
+print("=> Verify Host List for Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH)
+print(r.json())
+expected_json(r.json(), []) and expected_status(r, 200)
+
+print("=> Verify Host 10.2.0.2 Not In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 404)
+
+print("=> Directly Set Host List for Cluster 'honeynut' (w/ Malformed Request)")
+r = requests.put(
+    SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH,
+    json='Part of this nutritious breakfast!')
+print(r.json())
+expected_status(r, 400)
+
+print("=> Directly Set Host List for Cluster 'honeynut' (w/ Wrong Prev Value)")
+r = requests.put(
+    SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH,
+    json={"old": ["bogus"], "new": ["10.2.0.2"]})
+print(r.json())
+expected_status(r, 409)
+
+print("=> Verify Host 10.2.0.2 Not In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 404)
+
+print("=> Directly Set Host List for Cluster 'honeynut'")
+r = requests.put(
+    SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH,
+    json={"old": [], "new": ["10.2.0.2"]})
+print(r.json())
+expected_status(r, 200)
+
+print("=> Verify Host 10.2.0.2 In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 200)
+
+print("=> Deleting Host 10.2.0.2 (Implicitly Deleted From Cluster)")
 r = requests.delete(SERVER + '/api/v0/host/10.2.0.2', auth=AUTH)
 print(r.json())
 expected_status(r, 410)
 
-# FIXME: Verify no remaining hosts in cluster,
-#        once clusters have explicit members.
+print("=> Examining Cluster 'honeynut' (No Hosts)")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut', auth=AUTH)
+print(r.json())
+expect = {'status': 'ok', 'hosts': {'total': 0, 'available': 0, 'unavailable': 0}}
+expected_json(r.json(), expect) and expected_status(r, 200)
+
+print("=> Verify Host List for Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts', auth=AUTH)
+print(r.json())
+expected_json(r.json(), []) and expected_status(r, 200)
+
+print("=> Verify Host 10.2.0.2 Not In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
+print(r.json())
+expected_status(r, 404)
 
 print("=> Initiate Cluster Upgrade Without Auth (Should Fail)")
 r = requests.put(

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -194,7 +194,7 @@ class ClusterHostsResource(Resource):
         cluster name, if it exists, or else None.
 
         :param name: Name of a cluster
-        :type req: str
+        :type name: str
         """
         key = '/commissaire/clusters/{0}'.format(name)
         try:

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -189,6 +189,13 @@ class ClusterHostsResource(Resource):
     """
 
     def get_cluster_model(self, name):
+        """
+        Returns a Cluster instance from the etcd record for the given
+        cluster name, if it exists, or else None.
+
+        :param name: Name of a cluster
+        :type req: str
+        """
         key = '/commissaire/clusters/{0}'.format(name)
         try:
             etcd_resp = self.store.get(key)
@@ -199,8 +206,7 @@ class ClusterHostsResource(Resource):
             self.logger.info(
                 'Request of non-existent cluster {0} requested.'.format(name))
             return None
-        cluster = Cluster(**json.loads(etcd_resp.value))
-        return cluster
+        return Cluster(**json.loads(etcd_resp.value))
 
     def on_get(self, req, resp, name):
         """

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -76,9 +76,10 @@ class ClusterResource(Resource):
         :type cluster: str
         """
         try:
-            # TODO: This needs to be updated to only view hosts in
-            # it's own cluster. Since we are only dealing with
-            # a single cluster for MVP we will tag this as tech debt
+            # XXX: Not sure which wil be more efficient: fetch all
+            #      the host data in one etcd call and sort through
+            #      them, or fetch the ones we need individually.
+            #      For the MVP phase, fetch all is better.
             etcd_resp = self.store.get('/commissaire/hosts')
         except etcd.EtcdKeyNotFound:
             self.logger.warn(
@@ -86,15 +87,17 @@ class ClusterResource(Resource):
                 'Cannot determine cluster stats.')
             return
 
-        available = unavailable = 0
+        available = unavailable = total = 0
         for child in etcd_resp._children:
             host = Host(**json.loads(child['value']))
-            if host.status == 'active':
-                available += 1
-            else:
-                unavailable += 1
+            if host.address in cluster.hostset:
+                total += 1
+                if host.status == 'active':
+                    available += 1
+                else:
+                    unavailable += 1
 
-        cluster.hosts['total'] = len(etcd_resp._children)
+        cluster.hosts['total'] = total
         cluster.hosts['available'] = available
         cluster.hosts['unavailable'] = unavailable
 
@@ -148,7 +151,7 @@ class ClusterResource(Resource):
                 'Creation of already exisiting cluster {0} requested.'.format(
                     name))
         except etcd.EtcdKeyNotFound:
-            cluster = Cluster(status='ok')
+            cluster = Cluster(status='ok', hostset=[])
             etcd_resp = self.store.set(key, cluster.to_json(secure=True))
             self.logger.info(
                 'Created cluster {0} per request.'.format(name))
@@ -178,6 +181,192 @@ class ClusterResource(Resource):
                 'Deleting for non-existent cluster {0} requested.'.format(
                     name))
             resp.status = falcon.HTTP_404
+
+
+class ClusterHostsResource(Resource):
+    """
+    Resource for managing host membership in a Cluster.
+    """
+
+    def get_cluster_model(self, name):
+        key = '/commissaire/clusters/{0}'.format(name)
+        try:
+            etcd_resp = self.store.get(key)
+            self.logger.info(
+                'Request for cluster {0}.'.format(name))
+            self.logger.debug('{0}'.format(etcd_resp))
+        except etcd.EtcdKeyNotFound:
+            self.logger.info(
+                'Request of non-existent cluster {0} requested.'.format(name))
+            return None
+        cluster = Cluster(**json.loads(etcd_resp.value))
+        return cluster
+
+    def on_get(self, req, resp, name):
+        """
+        Handles GET requests for Cluster hosts.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The name of the Cluster being requested.
+        :type name: str
+        """
+        cluster = self.get_cluster_model(name)
+        if not cluster:
+            resp.status = falcon.HTTP_404
+            return
+
+        resp.body = json.dumps(cluster.hostset)
+        resp.status = falcon.HTTP_200
+
+    def on_put(self, req, resp, name):
+        """
+        Handles PUT requests for Cluster hosts.
+        This replaces the entire host list for a Cluster.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The name of the Cluster being requested.
+        :type name: str
+        """
+        try:
+            req_body = json.loads(req.stream.read().decode())
+            old_hosts = set(req_body['old'])  # Ensures no duplicates
+            new_hosts = set(req_body['new'])  # Ensures no duplicates
+        except (KeyError, TypeError):
+            self.logger.info(
+                'Bad client PUT request for cluster {0}: {1}'.
+                format(name, req_body))
+            resp.status = falcon.HTTP_400
+            return
+
+        cluster = self.get_cluster_model(name)
+        if not cluster:
+            resp.status = falcon.HTTP_404
+            return
+
+        # old_hosts must match current hosts to accept new_hosts.
+        # Note: Order doesn't matter, so etcd's atomic comparison
+        #       of the raw values would be too strict.
+        if old_hosts != set(cluster.hostset):
+            self.logger.info(
+                'Conflict setting hosts for cluster {0}'.format(name))
+            resp.status = falcon.HTTP_409
+            return
+
+        # FIXME: Need input validation.  For each new host,
+        #        - Does the host exist at /commissaire/hosts/{IP}?
+        #        - Does the host already belong to another cluster?
+
+        # FIXME: Should guard against races here, since we're fetching
+        #        the cluster record and writing it back with some parts
+        #        unmodified.  Use either locking or a conditional write
+        #        with the etcd 'modifiedIndex'.  Deferring for now.
+
+        key = '/commissaire/clusters/{0}'.format(name)
+        cluster.hostset = list(new_hosts)
+        self.store.set(key, cluster.to_json(secure=True))
+        resp.status = falcon.HTTP_200
+
+
+class ClusterSingleHostResource(ClusterHostsResource):
+    """
+    Resource for managing a single host's membership in a Cluster.
+    """
+
+    def on_get(self, req, resp, name, address):
+        """
+        Handles GET requests for individual hosts in a Cluster.
+        This is a membership test, returning 200 OK if the host
+        address is part of the cluster, or else 404 Not Found.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The name of the Cluster being requested.
+        :type name: str
+        :param address: The address of the Host being requested.
+        :type address: str
+        """
+        cluster = self.get_cluster_model(name)
+        if not cluster:
+            resp.status = falcon.HTTP_404
+            return
+
+        if address in cluster.hostset:
+            resp.status = falcon.HTTP_200
+        else:
+            resp.status = falcon.HTTP_404
+
+    def on_put(self, req, resp, name, address):
+        """
+        Handles PUT requests for individual hosts in a Cluster.
+        This adds a single host to the cluster, idempotently.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The name of the Cluster being requested.
+        :type name: str
+        :param address: The address of the Host being requested.
+        :type address: str
+        """
+        cluster = self.get_cluster_model(name)
+        if not cluster:
+            resp.status = falcon.HTTP_404
+            return
+
+        # FIXME: Need input validation.
+        #        - Does the host exist at /commissaire/hosts/{IP}?
+        #        - Does the host already belong to another cluster?
+
+        # FIXME: Should guard against races here, since we're fetching
+        #        the cluster record and writing it back with some parts
+        #        unmodified.  Use either locking or a conditional write
+        #        with the etcd 'modifiedIndex'.  Deferring for now.
+
+        key = '/commissaire/clusters/{0}'.format(name)
+        hostset = set(cluster.hostset)
+        hostset.add(address)  # Ensures no duplicates
+        cluster.hostset = list(hostset)
+        self.store.set(key, cluster.to_json(secure=True))
+        resp.status = falcon.HTTP_200
+
+    def on_delete(self, req, resp, name, address):
+        """
+        Handles DELETE requests for individual hosts in a Cluster.
+        This removes a single host from the cluster, idempotently.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The name of the Cluster being requested.
+        :type name: str
+        :param address: The address of the Host being requested.
+        :type address: str
+        """
+        cluster = self.get_cluster_model(name)
+        if not cluster:
+            resp.status = falcon.HTTP_404
+            return
+
+        # FIXME: Should guard against races here, since we're fetching
+        #        the cluster record and writing it back with some parts
+        #        unmodified.  Use either locking or a conditional write
+        #        with the etcd 'modifiedIndex'.  Deferring for now.
+
+        key = '/commissaire/clusters/{0}'.format(name)
+        if address in cluster.hostset:
+            cluster.hostset.remove(address)
+            self.store.set(key, cluster.to_json(secure=True))
+        resp.status = falcon.HTTP_200
 
 
 class ClusterRestartResource(Resource):

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -26,7 +26,8 @@ class Cluster(Model):
     Representation of a Cluster.
     """
     _json_type = dict
-    _attributes = ('status',)
+    _attributes = ('status', 'hostset')
+    _hidden_attributes = ('hostset',)
 
     def __init__(self, **kwargs):
         Model.__init__(self, **kwargs)
@@ -36,10 +37,13 @@ class Cluster(Model):
                       'unavailable': 0}
 
     # FIXME Generalize and move to Model?
-    def to_json_with_hosts(self):
+    def to_json_with_hosts(self, secure=False):
         data = {}
         for key in self._attributes:
-            data[key] = getattr(self, key)
+            if secure:
+                data[key] = getattr(self, key)
+            elif key not in self._hidden_attributes:
+                data[key] = getattr(self, key)
         data['hosts'] = self.hosts
         return json.dumps(data)
 
@@ -48,7 +52,6 @@ class ClusterRestart(Model):
     """
     Representation of a Cluster restart operation.
     """
-
     _json_type = dict
     _attributes = (
         'status', 'restarted', 'in_process',
@@ -59,7 +62,6 @@ class ClusterUpgrade(Model):
     """
     Representation of a Cluster upgrade operation.
     """
-
     _json_type = dict
     _attributes = (
         'status', 'upgrade_to', 'upgraded', 'in_process',

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -30,9 +30,10 @@ import gevent
 
 from gevent.pywsgi import WSGIServer
 
-from commissaire.handlers.clusters import \
-    ClustersResource, ClusterResource, \
-    ClusterRestartResource, ClusterUpgradeResource
+from commissaire.handlers.clusters import (
+    ClustersResource, ClusterResource,
+    ClusterHostsResource, ClusterSingleHostResource,
+    ClusterRestartResource, ClusterUpgradeResource)
 from commissaire.handlers.hosts import HostsResource, HostResource
 from commissaire.handlers.status import StatusResource
 from commissaire.queues import INVESTIGATE_QUEUE
@@ -119,6 +120,12 @@ def create_app(store):
 
     app.add_route('/api/v0/status', StatusResource(store, None))
     app.add_route('/api/v0/cluster/{name}', ClusterResource(store, None))
+    app.add_route(
+        '/api/v0/cluster/{name}/hosts',
+        ClusterHostsResource(store, None))
+    app.add_route(
+        '/api/v0/cluster/{name}/hosts/{address}',
+        ClusterSingleHostResource(store, None))
     app.add_route(
         '/api/v0/cluster/{name}/restart',
         ClusterRestartResource(store, None))

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -218,6 +218,14 @@ class Test_HostResource(TestCase):
         """
         Verify deleting a Host.
         """
+
+        clusters_return_value = MagicMock(
+            etcd.EtcdResult, leaves=[],
+            value={'value': None}, _children=[])
+        # First call return is etcd_host, second is the clusters_return_value
+        self.datasource.get.side_effect = (
+            MagicMock(value=self.etcd_host), clusters_return_value)
+
         # Verify deleting of an existing host works
         body = self.simulate_request('/api/v0/host/10.2.0.2', method='DELETE')
         # datasource's delete should have been called once


### PR DESCRIPTION
This makes three major changes:

1. The cluster record in etcd now includes a `hostset` list member containing the member hosts for the cluster.
2. New endpoints for querying and changing member hosts in a cluster.

   This can be done all at once:
   ```
   /api/v0/cluster/{NAME}/hosts
   ```
   Or individually:
   ```
   /api/v0/cluster/{NAME}/hosts/{IP}
   ```
   (see `doc/endpoints.rst` for further details)
3. Note that with this change, hosts must now be explicitly added to clusters.  However, host creation will soon support a means of specifying cluster membership.