### PR TITLE
Support specifying cluster in host creation

### DIFF
--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -305,6 +305,7 @@ Creates a new host record.
    {
        "address": string      // The IP address of the cluster host
        "ssh_priv_key": string // base64 encoded ssh private key
+       "cluster": string      // The cluster the host should be associated with
    }
 
 .. note::
@@ -317,6 +318,7 @@ Example
 
    {
        "address": "192.168.100.50",
+       "cluster": "default",
        "ssh_priv_key": "dGVzdAo..."
    }
 

--- a/example/rest_calls.py
+++ b/example/rest_calls.py
@@ -252,6 +252,39 @@ r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.2', auth=AUTH)
 print(r.json())
 expected_status(r, 404)
 
+print("=> Creating Host 10.2.0.3 With Bad Cluster (Should Fail)")
+r = requests.put(
+    SERVER + '/api/v0/host/10.2.0.3', auth=AUTH,
+    json={
+        "address": "10.2.0.3",
+        "ssh_priv_key": "dGVzdAo=",
+        "cluster": "headache"
+    })
+print(r.json())
+expected_status(r, 409)
+
+print("=> Make Sure There Are No New Clusters")
+r = requests.get(SERVER + '/api/v0/clusters', auth=AUTH)
+print(r.json())
+expect = ['honeynut']
+expected_json(r.json(), expect) and expected_status(r, 200)
+
+print("=> Creating Host 10.2.0.3 With 'honeynut' Cluster")
+r = requests.put(
+    SERVER + '/api/v0/host/10.2.0.3', auth=AUTH,
+    json={
+        "address": "10.2.0.3",
+        "ssh_priv_key": "dGVzdAo=",
+        "cluster": "honeynut"
+    })
+print(r.json())
+expected_status(r, 201)
+
+print("=> Verify Host 10.2.0.3 In Cluster 'honeynut'")
+r = requests.get(SERVER + '/api/v0/cluster/honeynut/hosts/10.2.0.3', auth=AUTH)
+print(r.json())
+expected_status(r, 200)
+
 print("=> Initiate Cluster Upgrade Without Auth (Should Fail)")
 r = requests.put(
     SERVER + '/api/v0/cluster/honeynut/upgrade',

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -120,7 +120,7 @@ class ClusterResource(Resource):
             self.logger.debug('{0}'.format(etcd_resp))
         except etcd.EtcdKeyNotFound:
             self.logger.info(
-                'Request of non-existent cluster {0} requested.'.format(name))
+                'Request for non-existent cluster {0}.'.format(name))
             resp.status = falcon.HTTP_404
             return
 
@@ -204,7 +204,7 @@ class ClusterHostsResource(Resource):
             self.logger.debug('{0}'.format(etcd_resp))
         except etcd.EtcdKeyNotFound:
             self.logger.info(
-                'Request of non-existent cluster {0} requested.'.format(name))
+                'Request for non-existent cluster {0}.'.format(name))
             return None
         return Cluster(**json.loads(etcd_resp.value))
 

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -106,24 +106,25 @@ class HostResource(Resource):
             resp.status = falcon.HTTP_409
             return
         except etcd.EtcdKeyNotFound:
-            data = req.stream.read().decode()
-            host_creation = json.loads(data)
-            ssh_priv_key = host_creation['ssh_priv_key']
-            host_creation['address'] = address
-            host_creation['os'] = ''
-            host_creation['status'] = 'investigating'
-            host_creation['cpus'] = -1
-            host_creation['memory'] = -1
-            host_creation['space'] = -1
-            host_creation['ssh_priv_key'] = ssh_priv_key
-            host_creation['last_check'] = None
-            host = Host(**host_creation)
-            new_host = self.store.set(
-                '/commissaire/hosts/{0}'.format(
-                    address), host.to_json(secure=True))
-            INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
-            resp.status = falcon.HTTP_201
-            req.context['model'] = Host(**json.loads(new_host.value))
+            pass
+
+        data = req.stream.read().decode()
+        host_creation = json.loads(data)
+        ssh_priv_key = host_creation['ssh_priv_key']
+        host_creation['address'] = address
+        host_creation['os'] = ''
+        host_creation['status'] = 'investigating'
+        host_creation['cpus'] = -1
+        host_creation['memory'] = -1
+        host_creation['space'] = -1
+        host_creation['last_check'] = None
+        host = Host(**host_creation)
+        new_host = self.store.set(
+            '/commissaire/hosts/{0}'.format(
+                address), host.to_json(secure=True))
+        INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
+        resp.status = falcon.HTTP_201
+        req.context['model'] = Host(**json.loads(new_host.value))
 
     def on_delete(self, req, resp, address):
         """

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -118,11 +118,46 @@ class HostResource(Resource):
         host_creation['memory'] = -1
         host_creation['space'] = -1
         host_creation['last_check'] = None
+
+        # Don't store the cluster name in etcd.
+        cluster_name = host_creation.pop('cluster', None)
+
+        # Verify the cluster exists, if given.  Do it now
+        # so we can fail before writing anything to etcd.
+        if cluster_name:
+            # XXX: Based on ClusterSingleHostResource.on_put().
+            #      Add a util module to share common operations.
+            cluster_key = '/commissaire/clusters/{0}'.format(cluster_name)
+            try:
+                etcd_resp = self.store.get(cluster_key)
+                self.logger.info(
+                    'Request for cluster {0}'.format(cluster_name))
+                self.logger.debug('{0}'.format(etcd_resp))
+            except etcd.EtcdKeyNotFound:
+                self.logger.info(
+                    'Request for non-existent cluster {0}.'.format(
+                        cluster_name))
+                resp.status = falcon.HTTP_409
+                return
+            cluster = Cluster(**json.loads(etcd_resp.value))
+            hostset = set(cluster.hostset)
+            hostset.add(address)  # Ensures no duplicates
+            cluster.hostset = list(hostset)
+
         host = Host(**host_creation)
         new_host = self.store.set(
             '/commissaire/hosts/{0}'.format(
                 address), host.to_json(secure=True))
         INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
+
+        # Add host to the requested cluster.
+        if cluster_name:
+            # FIXME: Should guard against races here, since we're fetching
+            #        the cluster record and writing it back with some parts
+            #        unmodified.  Use either locking or a conditional write
+            #        with the etcd 'modifiedIndex'.  Deferring for now.
+            self.store.set(cluster_key, cluster.to_json(secure=True))
+
         resp.status = falcon.HTTP_201
         req.context['model'] = Host(**json.loads(new_host.value))
 


### PR DESCRIPTION
Note, the cluster must be created first.

I also left the `cluster` argument optional.