### PR TITLE
Remove address from host creation

### DIFF
--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -303,9 +303,8 @@ Creates a new host record.
 .. code-block:: javascript
 
    {
-       "address": string      // The IP address of the cluster host
        "ssh_priv_key": string // base64 encoded ssh private key
-       "cluster": string      // The cluster the host should be associated with
+       "cluster": string      // Optional cluster the host should be associated with
    }
 
 .. note::
@@ -317,7 +316,6 @@ Example
 .. code-block:: javascript
 
    {
-       "address": "192.168.100.50",
        "cluster": "default",
        "ssh_priv_key": "dGVzdAo..."
    }

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -99,5 +99,5 @@ Verify that Commissaire is running as a container or in the virtual environment 
 
 .. code-block:: shell
 
-   curl -u "a:a" -XPUT -H "Content-Type: application/json" http://localhost:8000/api/v0/host/192.168.1.100 -d '{"host": "192.168.1.100", "cluster": "datacenter1", "ssh_priv_key": "dGVzdAo="}'
+   curl -u "a:a" -XPUT -H "Content-Type: application/json" http://localhost:8000/api/v0/host/192.168.1.100 -d '{"cluster": "datacenter1", "ssh_priv_key": "dGVzdAo="}'
    ...

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -16,7 +16,6 @@
 Host(s) handlers.
 
 """
-import datetime
 import falcon
 import etcd
 import json

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -251,8 +251,7 @@ class Test_HostResource(TestCase):
         self.datasource.get.side_effect = (
             etcd.EtcdKeyNotFound, MagicMock(value=self.etcd_cluster))
         self.return_value.value = self.etcd_host
-        data = ('{"address": "10.2.0.2",'
-                ' "ssh_priv_key": "dGVzdAo=",'
+        data = ('{"ssh_priv_key": "dGVzdAo=",'
                 ' "cluster": "testing"}')
         body = self.simulate_request(
             '/api/v0/host/10.2.0.2', method='PUT', body=data)


### PR DESCRIPTION
Removes the need for "address" from when creating a new host. As @mbarnes noted, it is redundant.

**Note**: This sits on top of https://github.com/projectatomic/commissaire/pull/30. DO NOTE MERGE until https://github.com/projectatomic/commissaire/pull/30 has been merged.