### PR TITLE
Fix host filtering bug in clusterexec

### DIFF
--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -71,7 +71,7 @@ def clusterexec(cluster_name, command, store):
     if cluster_hosts:
         logger.debug(
             '{0} hosts in cluster {1}'.format(
-            len(cluster_hosts), cluster_name))
+                len(cluster_hosts), cluster_name))
     else:
         logger.warn('No hosts in cluster {1}'.format(cluster_name))
 

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -65,10 +65,20 @@ def clusterexec(cluster_name, command, store):
         '/commissaire/cluster/{0}/{1}'.format(cluster_name, command),
         json.dumps(cluster_status))
 
+    # Collect all host addresses in the cluster
+    etcd_resp = store.get('/commissaire/clusters/{0}'.format(cluster_name))
+    cluster_hosts = set(json.loads(etcd_resp.value).get('hostset', []))
+    if cluster_hosts:
+        logger.debug(
+            '{0} hosts in cluster {1}'.format(
+            len(cluster_hosts), cluster_name))
+    else:
+        logger.warn('No hosts in cluster {1}'.format(cluster_name))
+
     # TODO: Find better way to do this
     for a_host_dict in store.get('/commissaire/hosts')._children:
         a_host = json.loads(a_host_dict['value'])
-        if a_host['cluster'] != cluster_name:
+        if a_host['address'] not in cluster_hosts:
             logger.debug('Skipping {0} as it is not in this cluster.'.format(
                 a_host['address']))
             continue  # Move on to the next one

--- a/test/test_jobs_clusterexec.py
+++ b/test/test_jobs_clusterexec.py
@@ -35,6 +35,8 @@ class Test_JobsClusterExec(TestCase):
                  ' "last_check": "2015-12-17T15:48:18.710454", '
                  '"cluster": "default"}')
 
+    etcd_cluster = '{"status": "ok", "hostset": ["10.2.0.2"]}'
+
     def test_clusterexec(self):
         """
         Verify the clusterexec.
@@ -49,12 +51,14 @@ class Test_JobsClusterExec(TestCase):
 
                 store = etcd.Client()
                 store.get = MagicMock('get')
-                store.get.return_value = return_value
+                store.get.side_effect = (
+                    MagicMock(value=self.etcd_cluster), return_value)
                 store.set = MagicMock('set')
 
                 clusterexec('default', cmd, store)
 
-                self.assertEquals(1, store.get.call_count)
+                # One for the cluster, one for the host
+                self.assertEquals(2, store.get.call_count)
                 # We should have 4 sets for 1 host
                 self.assertEquals(4, store.set.call_count)
 
@@ -72,11 +76,13 @@ class Test_JobsClusterExec(TestCase):
 
                 store = etcd.Client()
                 store.get = MagicMock('get')
-                store.get.return_value = return_value
+                store.get.side_effect = (
+                    MagicMock(value=self.etcd_cluster), return_value)
                 store.set = MagicMock('set')
 
                 clusterexec('default', cmd, store)
 
-                self.assertEquals(1, store.get.call_count)
+                # One for the cluster, one for the host
+                self.assertEquals(2, store.get.call_count)
                 # We should have 4 sets for 1 host
                 self.assertEquals(3, store.set.call_count)


### PR DESCRIPTION
Look up the cluster record in etcd to get the member hosts by address.
The host record in etcd no longer has a 'cluster' member.