### PR TITLE
PUT's should be idempotent

### DIFF
--- a/doc/enums.rst
+++ b/doc/enums.rst
@@ -33,7 +33,7 @@ Host Statuses
 Upgrade Statuses
 ~~~~~~~~~~~~~~~~
 
-* **inprocess**: The cluster is currently upgrading hosts.
+* **in_process**: The cluster is currently upgrading hosts.
 * **finished**: The cluster successfully upgraded.
 * **failed**: The cluster could not upgrade.
 

--- a/example/rest_calls.py
+++ b/example/rest_calls.py
@@ -65,24 +65,21 @@ expected_status(r, 404)
 print("=> Creating Host 10.2.0.2")
 r = requests.put(
     SERVER + '/api/v0/host/10.2.0.2', auth=AUTH,
-    json={
-        "address": "10.2.0.2",
-        "ssh_priv_key": "dGVzdAo=",
-    })
+    json={"ssh_priv_key": "dGVzdAo="})
 print(r.json())
 expected_status(r, 201)
 
-print("=> Creating Host Again 10.2.0.2 (Should Fail)")
+print("=> Recreating Compatible Host 10.2.0.2")
 r = requests.put(
     SERVER + '/api/v0/host/10.2.0.2', auth=AUTH,
-    json={
-        "address": "10.2.0.2",
-        "status": "available",
-        "os": "atomic",
-        "cpus": 2,
-        "memory": 11989228,
-        "space": 487652,
-        "last_check": "2015-12-17T15:48:18.710454"})
+    json={"ssh_priv_key": "dGVzdAo="})
+print(r.json())
+expected_status(r, 200)
+
+print("=> Recreating Incompatible Host 10.2.0.2 (Should Fail)")
+r = requests.put(
+    SERVER + '/api/v0/host/10.2.0.2', auth=AUTH,
+    json={"ssh_priv_key": "boguskey"})
 print(r.json())
 expected_status(r, 409)
 

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Resource utilities.
+"""
+
+import etcd
+import json
+
+from commissaire.handlers.models import Cluster
+
+
+def etcd_host_key(address):
+    """
+    Returns the etcd key for the given host address.
+
+    :param address: Address of a host
+    :type address: str
+    """
+    return '/commissaire/hosts/{0}'.format(address)
+
+
+def etcd_cluster_key(name):
+    """
+    Returns the etcd key for the given cluster name.
+
+    :param name: Name of a cluster
+    :type name: str
+    """
+    return '/commissaire/clusters/{0}'.format(name)
+
+
+def etcd_cluster_exists(resource, name):
+    """
+    Returns whether a cluster with the given name exists.
+
+    :param resource: A Resource instance
+    :type resource: commissaire.resource.Resource
+    :param name: Name of a cluster
+    :type name: str
+    """
+    key = etcd_cluster_key(name)
+    try:
+        resource.store.get(key)
+        return True
+    except etcd.EtcdKeyNotFound:
+        return False
+
+
+def etcd_cluster_has_host(resource, name, address):
+    """
+    Checks if a host address belongs to a cluster with the given name.
+    If no such cluster exists, the function raises KeyError.
+
+    :param resource: A Resource instance
+    :type resource: commissaire.resource.Resource
+    :param name: Name of a cluster
+    :type name: str
+    :param address: Host address
+    :type address: str
+    """
+    cluster = get_cluster_model(resource, name)
+    if not cluster:
+        raise KeyError
+
+    return address in cluster.hostset
+
+
+def etcd_cluster_add_host(resource, name, address):
+    """
+    Adds a host address to a cluster with the given name.
+    If no such cluster exists, the function raises KeyError.
+
+    Note the function is idempotent: if the host address is
+    already in the cluster, no change occurs.
+
+    :param resource: A Resource instance
+    :type resource: commissaire.resource.Resource
+    :param name: Name of a cluster
+    :type name: str
+    :param address: Host address to add
+    :type address: str
+    """
+    cluster = get_cluster_model(resource, name)
+    if not cluster:
+        raise KeyError
+
+    # FIXME: Need input validation.
+    #        - Does the host exist at /commissaire/hosts/{IP}?
+    #        - Does the host already belong to another cluster?
+
+    # FIXME: Should guard against races here, since we're fetching
+    #        the cluster record and writing it back with some parts
+    #        unmodified.  Use either locking or a conditional write
+    #        with the etcd 'modifiedIndex'.  Deferring for now.
+
+    if address not in cluster.hostset:
+        cluster.hostset.append(address)
+        resource.store.set(cluster.etcd.key, cluster.to_json(secure=True))
+
+
+def etcd_cluster_remove_host(resource, name, address):
+    """
+    Removes a host address from a cluster with the given name.
+    If no such cluster exists, the function raises KeyError.
+
+    Note the function is idempotent: if the host address is
+    not in the cluster, no change occurs.
+
+    :param resource: A Resource instance
+    :type resource: commissaire.resource.Resource
+    :param name: Name of a cluster
+    :type name: str
+    :param address: Host address to remove
+    :type address: str
+    """
+    cluster = get_cluster_model(resource, name)
+    if not cluster:
+        raise KeyError
+
+    # FIXME: Should guard against races here, since we're fetching
+    #        the cluster record and writing it back with some parts
+    #        unmodified.  Use either locking or a conditional write
+    #        with the etcd 'modifiedIndex'.  Deferring for now.
+
+    if address in cluster.hostset:
+        cluster.hostset.remove(address)
+        resource.store.set(cluster.etcd.key, cluster.to_json(secure=True))
+
+
+def get_cluster_model(resource, name):
+    """
+    Returns a Cluster instance from the etcd record for the given
+    cluster name, if it exists, or else None.
+
+    For convenience, the EtcdResult is embedded in the Cluster instance
+    as an 'etcd' property.
+
+    :param resource: A Resource instance
+    :type resource: commissaire.resource.Resource
+    :param name: Name of a cluster
+    :type name: str
+    """
+    key = etcd_cluster_key(name)
+    try:
+        etcd_resp = resource.store.get(key)
+        resource.logger.info(
+            'Request for cluster {0}.'.format(name))
+        resource.logger.debug('{0}'.format(etcd_resp))
+    except etcd.EtcdKeyNotFound:
+        resource.logger.info(
+            'Request for non-existent cluster {0}.'.format(name))
+        return None
+    cluster = Cluster(**json.loads(etcd_resp.value))
+    cluster.etcd = etcd_resp
+    return cluster

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -39,7 +39,7 @@ def clusterexec(cluster_name, command, store):
     if command == 'upgrade':
         finished_hosts_key = 'upgraded'
         cluster_status = {
-            "status": 'inprocess',
+            "status": 'in_process',
             "upgrade_to": 'latest',
             "upgraded": [],
             "in_process": [],
@@ -49,7 +49,7 @@ def clusterexec(cluster_name, command, store):
     elif command == 'restart':
         finished_hosts_key = 'restarted'
         cluster_status = {
-            "status": 'inprocess',
+            "status": 'in_process',
             "restarted": [],
             "in_process": [],
             "started_at": datetime.datetime.utcnow().isoformat(),

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -233,13 +233,21 @@ class Test_ClusterResource(TestCase):
         # Verify with proper deletion
         body = self.simulate_request(
             '/api/v0/cluster/development', method='DELETE')
+        # Get is called to verify cluster exists
+        self.assertEquals(1, self.datasource.get.call_count)
+        self.assertEquals(1, self.datasource.delete.call_count)
         self.assertEquals(falcon.HTTP_410, self.srmock.status)
         self.assertEquals('{}', body[0])
 
         # Verify when key doesn't exist
-        self.datasource.delete.side_effect = etcd.EtcdKeyNotFound
+        self.datasource.get.reset_mock()
+        self.datasource.delete.reset_mock()
+        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
         body = self.simulate_request(
             '/api/v0/cluster/development', method='DELETE')
+        # Get is called to verify cluster exists
+        self.assertEquals(1, self.datasource.get.call_count)
+        self.assertEquals(0, self.datasource.delete.call_count)
         self.assertEquals(falcon.HTTP_404, self.srmock.status)
         self.assertEquals('{}', body[0])
 

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -268,7 +268,7 @@ class Test_ClusterRestart(TestCase):
 
         # Make sure a Cluster creates expected results
         cluster_restart_model = clusters.ClusterRestart(
-            status='inprocess', restarted=[], in_process=[],
+            status='in_process', restarted=[], in_process=[],
             started_at=None, finished_at=None)
 
         self.assertEquals(type(str()), type(cluster_restart_model.to_json()))
@@ -281,6 +281,8 @@ class Test_ClusterRestartResource(TestCase):
 
     arestart = ('{"status": "", "restarted": "", "in_process": "",'
                 ' "started_at": "", "finished_at": ""}')
+
+    etcd_cluster = '{"status": "ok", "hostset": ["10.2.0.2"]}'
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
@@ -314,6 +316,9 @@ class Test_ClusterRestartResource(TestCase):
         Verify creating a cluster restart.
         """
         # Verify with creation
+        self.datasource.get.side_effect = (
+            MagicMock(value=self.etcd_cluster),
+            etcd.EtcdKeyNotFound)
         body = self.simulate_request(
             '/api/v0/cluster/development/restart',
             method='PUT')
@@ -550,7 +555,7 @@ class Test_ClusterUpgrade(TestCase):
 
         # Make sure a Cluster Upgrade creates expected results
         cluster_upgrade_model = clusters.ClusterUpgrade(
-            status='inprocess', upgrade_to='', upgraded=[], in_process=[],
+            status='in_process', upgrade_to='', upgraded=[], in_process=[],
             started_at=None, finished_at=None)
 
         self.assertEquals(type(str()), type(cluster_upgrade_model.to_json()))
@@ -564,6 +569,8 @@ class Test_ClusterUpgradeResource(TestCase):
     aupgrade = ('{"status": "ok", "upgrade_to": "7.0.2", "upgraded": [],'
                 ' "in_process": [], "started_at": "",'
                 ' "finished_at": "0001-01-01T00:00:00"}')
+
+    etcd_cluster = '{"status": "ok", "hostset": ["10.2.0.2"]}'
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
@@ -597,6 +604,10 @@ class Test_ClusterUpgradeResource(TestCase):
         """
         Verify creating a cluster.
         """
+        self.datasource.get.side_effect = (
+            MagicMock(value=self.etcd_cluster),
+            etcd.EtcdKeyNotFound)
+
         # Verify sending no/bad data returns a 400
         for put_data in (None, '{"nothing": "here"}"'):
             body = self.simulate_request(

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -249,7 +249,9 @@ class Test_HostResource(TestCase):
         """
 
         self.datasource.get.side_effect = (
-            etcd.EtcdKeyNotFound, MagicMock(value=self.etcd_cluster))
+            etcd.EtcdKeyNotFound,
+            MagicMock(value=self.etcd_cluster),
+            MagicMock(value=self.etcd_cluster))
         self.return_value.value = self.etcd_host
         data = ('{"ssh_priv_key": "dGVzdAo=",'
                 ' "cluster": "testing"}')


### PR DESCRIPTION
This makes **PUT Host** and **PUT Cluster Restart/Upgrade** conditionally idempotent (conditional on the request body not conflicting with the existing resource).

The first commit is just some refactoring work.

In the last commit I changed the status enum to `in_process`, because we were using both `inprocess` and `in_process` (mostly the latter) throughout the code.  I can go the other way on that if you'd prefer.