### PR TITLE
Use py-bcrypt instead of bcrypt

### DIFF
--- a/conf/users.json
+++ b/conf/users.json
@@ -1,5 +1,5 @@
 {
     "a": {
-        "hash": "$2b$12$PtOoiwTvFBAJPMfrZn7pXubcx5MBbQiLVEDv3LAVWGeKiZZiYRGlu"
+        "hash": "$2a$12$SQPstqN3Ci95hYZ4u/syluTx8M5wSVwfhcC.iiawjoVck7Qyh43Ni"
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gevent==1.1rc3
 falcon>=0.3
 requests
-bcrypt
+py-bcrypt
 python-etcd==0.4.2
 setuptools
 ansible>=2.0.0.2

--- a/src/commissaire/authentication/httpauth.py
+++ b/src/commissaire/authentication/httpauth.py
@@ -66,11 +66,14 @@ class _HTTPBasicAuth(Authenticator):
             if user in self._data.keys():
                 self.logger.debug('User {0} found in datastore.'.format(user))
                 hashed = self._data[user]['hash'].encode('utf-8')
-                if bcrypt.hashpw(passwd.encode('utf-8'), hashed) == hashed:
-                    self.logger.debug(
-                        'The provided hash for user {0} matched: {1}'.format(
-                            user, passwd))
-                    return  # Authentication is good
+                try:
+                    if bcrypt.hashpw(passwd.encode('utf-8'), hashed) == hashed:
+                        self.logger.debug(
+                            'The provided hash for user {0} '
+                            'matched: {1}'.format(user, passwd))
+                        return  # Authentication is good
+                except ValueError:
+                    pass  # Bad salt
 
         # Forbid by default
         raise falcon.HTTPForbidden('Forbidden', 'Forbidden')

--- a/src/commissaire/hash_pass_script.py
+++ b/src/commissaire/hash_pass_script.py
@@ -42,7 +42,7 @@ def main():
     else:
         password = getpass.getpass()
 
-    hashed = bcrypt.hashpw(password, bcrypt.gensalt(rounds=args.rounds))
+    hashed = bcrypt.hashpw(password, bcrypt.gensalt(log_rounds=args.rounds))
     sys.stdout.write('{0}\n'.format(hashed))
 
 


### PR DESCRIPTION
Because `py-bcrypt` is already packaged in Fedora, and I'm lazy.

Note the `gensalt()` function produces different results, even with the same number of rounds.  This will invalidate existing password hashes generated by `commissaire-hashpass` but I think it's still early enough that we can get away with it.