### PR TITLE
investigator now uses multiprocessing instead of greenlet.

### DIFF
--- a/doc/components.rst
+++ b/doc/components.rst
@@ -13,14 +13,14 @@ commissaire developers.
 
 Investigator
 ~~~~~~~~~~~~
-The investigator is a daemon like greenlet which is tasked with investigating
+The investigator is a subprocess which is tasked with investigating
 and bootstrapping new host nodes. When a new host is added it's the
 investigator which populates the host data in etcd and gets the right services
 going on the new host.
 
 ClusterExecPool
 ~~~~~~~~~~~~~~~
-This is a static pool used for executing commands across a cluster. For
+This is a static greenlet pool used for executing commands across a cluster. For
 instance, a reboot of a cluser will utilize this pool to execute remote commands
 in their own greenlet. Because the pool is limited there will only ever be X
 number of the command being executed at once.

--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -19,7 +19,7 @@ Status handlers.
 import falcon
 import etcd
 
-from commissaire.jobs import POOLS
+from commissaire.jobs import POOLS, PROCS
 from commissaire.resource import Resource
 from commissaire.handlers.models import Status
 
@@ -69,6 +69,13 @@ class StatusResource(Resource):
         except etcd.EtcdKeyNotFound:
             self.logger.debug('There is no root directory in etcd...')
             kwargs['etcd']['status'] = 'FAILED'
+
+        # Check investigator proccess
+        # XXX: Change investigator if more than 1 process is allowed
+        if PROCS['investigator'].is_alive():
+            kwargs['investigator']['status'] = 'OK'
+            kwargs['investigator']['info']['size'] = 1
+            kwargs['investigator']['info']['in_use'] = 1
 
         # Check all the pools
         def populate_pool_info(pool):

--- a/src/commissaire/jobs/__init__.py
+++ b/src/commissaire/jobs/__init__.py
@@ -20,6 +20,10 @@ from gevent.pool import Pool
 
 #: All green pools
 POOLS = {
-    'investigator': Pool(1),
     'clusterexecpool': Pool(5),
+}
+
+#: All multiprocessing processes
+PROCS = {
+    'investigator': None,
 }

--- a/src/commissaire/queues.py
+++ b/src/commissaire/queues.py
@@ -16,10 +16,10 @@
 All global queues.
 """
 
-from gevent.queue import Queue
+from multiprocessing import Queue as MPQueue
 
 #: Input queue for the investigator thread(s)
-INVESTIGATE_QUEUE = Queue()
+INVESTIGATE_QUEUE = MPQueue()
 
 
 # ROUTER_QUEUE = Queue()

--- a/test/test_handlers_status.py
+++ b/test/test_handlers_status.py
@@ -25,7 +25,7 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import status
 from commissaire.middleware import JSONify
-from commissaire.jobs import POOLS
+from commissaire.jobs import POOLS, PROCS
 
 
 class Test_Status(TestCase):
@@ -75,12 +75,18 @@ class Test_StatusResource(TestCase):
         self.return_value._children = [child]
         self.return_value.leaves = self.return_value._children
 
-        for pool in ('investigator', 'clusterexecpool'):
+        for pool in ('clusterexecpool', ):
             POOLS[pool] = MagicMock(
                 'gevent.pool.Pool',
                 size=1,
                 free_count=lambda: 0,
                 greenlets=[])
+
+        for proc in ('investigator', ):
+            PROCS[proc] = MagicMock(
+                'multiprocessing.Process',
+                is_alive=MagicMock(return_value=True),
+            )
 
         body = self.simulate_request('/api/v0/status')
         # datasource's get should have been called once


### PR DESCRIPTION
The investigator now runs in it's on process via  rather than using a single greenlet. This should avoid the case seen in some bootstrap cases.
