### PR TITLE
fix: Host creation should always store an address.

### DIFF
--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -106,6 +106,7 @@ class HostResource(Resource):
             # Don't treat it as a skeletal host record.
             req_data = req.stream.read()
             req_body = json.loads(req_data.decode())
+            req_body['address'] = address
             ssh_priv_key = req_body['ssh_priv_key']
             # Cluster member is optional.
             cluster_name = req_body.get('cluster', None)


### PR DESCRIPTION
I think this got missed since "old" scripts included host in the ```PUT```.