### PR TITLE
ansibleapi now uses playbook files.

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -48,38 +48,38 @@ Ansible Templates
 Variables are used with jinja2 templates and should always prefix
 **commissaire_**. Here is a current list variables in use as examples:
 
-====================================== ======================================================
-Name                                   Description
-====================================== ======================================================
-commissaire_targets                    Host(s) to target
-commissaire_install_libselinux_python  Command to install libselinux-python
-commissaire_install_flannel            Command to install flannel
-commissaire_flanneld_config_local      Local flannel config file to template to the target(s)
-commissaire_flanneld_config            Remote path to the flannel config
-commissaire_flannel_service            Name of the flannel service
-commissaire_install_docker             Command to install docker
-commissaire_docker_config_local        Local docker config file to template to the target(s)
-commissaire_docker_config              Remote path to the docker config
-commissaire_docker_service             Name of the docker service
-commissaire_install_kube               Command to install kubernetes minion packages
-commissaire_kube_config_config_local   Local kubernetes config file to template to the target(s)
-commissaire_kube_config_config         Remote path to the kubernetes config
-commissaire_kubeconfig_config_local    Local kubeconfig file to template to the target(s)
-commissaire_kubeconfig_config          Remote path to the kubeconfig
-commissaire_kubelet_service            Name of the kubelet service
-commissaire_kubeproxy_service          Name of the kubernetes proxy service
-commissaire_restart_command            Host restart command
-commissaire_upgrade_command            Host upgrade command
-commissaire_bootstrap_ip               The IP address of the host
-commissaire_kubernetes_api_server_host The kubernetes api server host
-commissaire_kubernetes_api_server_port The kubernetes api server port
-commissaire_kubernetes_bearer_token    The bearer token used to contact kubernetes
-commissaire_docker_registry_host       The docker registry host
-commissaire_docker_registry_port       The docker registry port
-commissaire_etcd_host                  The etcd host
-commissaire_etcd_port                  The etcd port
-commissaire_flannel_key                The flannel configuration key
-====================================== ======================================================
+============================================= ======================================================
+Name                                          Description
+============================================= ======================================================
+commissaire_targets                           Host(s) to target
+commissaire_install_libselinux_python         Command to install libselinux-python
+commissaire_install_flannel                   Command to install flannel
+commissaire_flanneld_config_local             Local flannel config file to template to the target(s)
+commissaire_flanneld_config                   Remote path to the flannel config
+commissaire_flannel_service                   Name of the flannel service
+commissaire_install_docker                    Command to install docker
+commissaire_docker_config_local               Local docker config file to template to the target(s)
+commissaire_docker_config                     Remote path to the docker config
+commissaire_docker_service                    Name of the docker service
+commissaire_install_kube                      Command to install kubernetes minion packages
+commissaire_kubernetes_config_local           Local kubernetes config file to template to the target(s)
+commissaire_kubernetes_config                 Remote path to the kubernetes config
+commissaire_kubeconfig_config_local           Local kubeconfig file to template to the target(s)
+commissaire_kubeconfig_config                 Remote path to the kubeconfig
+commissaire_kubelet_service                   Name of the kubelet service
+commissaire_kubeproxy_service                 Name of the kubernetes proxy service
+commissaire_restart_command                   Host restart command
+commissaire_upgrade_command                   Host upgrade command
+commissaire_bootstrap_ip                      The IP address of the host
+commissaire_kubernetes_api_server_host        The kubernetes api server host
+commissaire_kubernetes_api_server_port        The kubernetes api server port
+commissaire_kubernetes_bearer_token           The bearer token used to contact kubernetes
+commissaire_docker_registry_host              The docker registry host
+commissaire_docker_registry_port              The docker registry port
+commissaire_etcd_host                         The etcd host
+commissaire_etcd_port                         The etcd port
+commissaire_flannel_key                       The flannel configuration key
+============================================= ======================================================
 
 Compatibility
 ~~~~~~~~~~~~~

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -29,15 +29,57 @@ Of these, the most important to be up to speed on are:
 
 - gevent: http://www.gevent.org/
 - falcon: http://falconframework.org/
+- ansible: https://www.ansible.com/
 
-Coding Standards
------------------
+Standards
+---------
 
-Convention
-~~~~~~~~~~
+Conventions
+~~~~~~~~~~~
+
+Code
+````
 Like most projects commissaire expects specific coding standards to be followed.
 `pep8 <https://www.python.org/dev/peps/pep-0008/>`_ is followed strictly with
 the exception of E402: module level import not at top of file.
+
+Ansible Templates
+`````````````````
+Variables are used with jinja2 templates and should always prefix
+**commissaire_**. Here is a current list variables in use as examples:
+
+====================================== ======================================================
+Name                                   Description
+====================================== ======================================================
+commissaire_targets                    Host(s) to target
+commissaire_install_libselinux_python  Command to install libselinux-python
+commissaire_install_flannel            Command to install flannel
+commissaire_flanneld_config_local      Local flannel config file to template to the target(s)
+commissaire_flanneld_config            Remote path to the flannel config
+commissaire_flannel_service            Name of the flannel service
+commissaire_install_docker             Command to install docker
+commissaire_docker_config_local        Local docker config file to template to the target(s)
+commissaire_docker_config              Remote path to the docker config
+commissaire_docker_service             Name of the docker service
+commissaire_install_kube               Command to install kubernetes minion packages
+commissaire_kube_config_config_local   Local kubernetes config file to template to the target(s)
+commissaire_kube_config_config         Remote path to the kubernetes config
+commissaire_kubeconfig_config_local    Local kubeconfig file to template to the target(s)
+commissaire_kubeconfig_config          Remote path to the kubeconfig
+commissaire_kubelet_service            Name of the kubelet service
+commissaire_kubeproxy_service          Name of the kubernetes proxy service
+commissaire_restart_command            Host restart command
+commissaire_upgrade_command            Host upgrade command
+commissaire_bootstrap_ip               The IP address of the host
+commissaire_kubernetes_api_server_host The kubernetes api server host
+commissaire_kubernetes_api_server_port The kubernetes api server port
+commissaire_kubernetes_bearer_token    The bearer token used to contact kubernetes
+commissaire_docker_registry_host       The docker registry host
+commissaire_docker_registry_port       The docker registry port
+commissaire_etcd_host                  The etcd host
+commissaire_etcd_port                  The etcd port
+commissaire_flannel_key                The flannel configuration key
+====================================== ======================================================
 
 Compatibility
 ~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ py-bcrypt
 python-etcd==0.4.2
 setuptools
 ansible>=2.0.0.2
-jinja2

--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -24,7 +24,7 @@
     - name: Configure Kubernetes Node
       template:
         dest: "{{ commissaire_kube_config_config }}"
-        src: "{{  commissaire_kube_config_config_local }}"
+        src: "{{ commissaire_kube_config_config_local }}"
         force: yes
     - name: Add Kubernetes kubeconfig
       template:

--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -1,0 +1,48 @@
+---
+- name: bootstrap
+  hosts: commissaire_targets
+  gather_facts: no
+  tasks:
+    - name: Install libselinux-python
+      command: "{{ commissaire_install_libselinux_python }}"
+    - name: Install Flannel
+      command: "{{ commissaire_install_flannel }}"
+    - name: Configure Flannel
+      template:
+        src: "{{ commissaire_flanneld_config_local }}"
+        dest: "{{ commissaire_flanneld_config }}"
+        force: yes
+    - name: Install Docker
+      command: "{{ commissaire_install_docker }}"
+    - name: Configure Docker
+      template:
+        dest: "{{ commissaire_docker_config }}"
+        src: "{{ commissaire_docker_config_local }}"
+        force: yes
+    - name: Install Kubernetes Node
+      command: "{{ commissaire_install_kube }}"
+    - name: Configure Kubernetes Node
+      template:
+        dest: "{{ commissaire_kube_config_config }}"
+        src: "{{  commissaire_kube_config_config_local }}"
+        force: yes
+    - name: Add Kubernetes kubeconfig
+      template:
+        dest: "{{ commissaire_kubeconfig_config }}"
+        src: "{{ commissaire_kubeconfig_config_local }}"
+        force: yes
+    - name: Configure Kubernetes kubelet
+      template:
+        dest: "{{ commissaire_kubelet_config }}"
+        src: "{{ commissaire_kubelet_config_local }}"
+        force: yes
+    - name: Enable and Start Services
+      service:
+        name: "{{ item }}"
+        enabled: yes
+        state: started
+      with_items:
+        - "{{ commissaire_flannel_service }}"
+        - "{{ commissaire_docker_service }}"
+        - "{{ commissaire_kubelet_service }}"
+        - "{{ commissaire_kubeproxy_service }}"

--- a/src/commissaire/data/ansible/playbooks/get_info.yaml
+++ b/src/commissaire/data/ansible/playbooks/get_info.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: commissaire_targets
+  name: gather
+  gather_facts: 'yes'
+  tasks: []

--- a/src/commissaire/data/ansible/playbooks/get_info.yaml
+++ b/src/commissaire/data/ansible/playbooks/get_info.yaml
@@ -1,5 +1,5 @@
 ---
 - hosts: commissaire_targets
   name: gather
-  gather_facts: 'yes'
+  gather_facts: yes
   tasks: []

--- a/src/commissaire/data/ansible/playbooks/restart.yaml
+++ b/src/commissaire/data/ansible/playbooks/restart.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: commissaire_targets
+  name: restart
+  gather_facts: no
+  tasks:
+    - name: restart host
+      command: "{{ commissaire_restart_command }}"

--- a/src/commissaire/data/ansible/playbooks/upgrade.yaml
+++ b/src/commissaire/data/ansible/playbooks/upgrade.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: commissaire_targets
+  name: upgrade
+  gather_facts: no
+  tasks:
+    - name: upgrade host
+      command: "{{ commissaire_upgrade_command }}"

--- a/src/commissaire/data/templates/docker
+++ b/src/commissaire/data/templates/docker
@@ -1,2 +1,2 @@
-OPTIONS='--registry-mirror=http://{{ docker_registry_host }}:{{ docker_registry_port }} --selinux-enabled --log-driver=journald'
+OPTIONS='--registry-mirror=http://{{ commissaire_docker_registry_host }}:{{ commissaire_docker_registry_port }} --selinux-enabled --log-driver=journald'
 DOCKER_CERT_PATH=/etc/docker

--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,2 +1,2 @@
-FLANNEL_ETCD="http://{{ etcd_host }}:{{ etcd_port }}"
-FLANNEL_ETCD_KEY="{{ flannel_key }}"
+FLANNEL_ETCD="http://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
+FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"

--- a/src/commissaire/data/templates/kube_config
+++ b/src/commissaire/data/templates/kube_config
@@ -1,1 +1,1 @@
-KUBE_MASTER="--master=http://{{ kubernetes_api_server_host }}:{{ kubernetes_api_server_port }}"
+KUBE_MASTER="--master=http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"

--- a/src/commissaire/data/templates/kubeconfig
+++ b/src/commissaire/data/templates/kubeconfig
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
     api-version: v1
     insecure-skip-tls-verify: true
-    server: http://{{ kubernetes_api_server_host }}:{{ kubernetes_api_server_port }}
+    server: http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}
   name: cluster
 contexts:
 - context:
@@ -16,4 +16,4 @@ preferences:
 users:
 - name: commissairenode
   user:
-    token: {{ kubernetes_bearer_token }}
+    token: {{ commissaire_kubernetes_bearer_token }}

--- a/src/commissaire/data/templates/kubelet
+++ b/src/commissaire/data/templates/kubelet
@@ -1,3 +1,3 @@
 KUBELET_ADDRESS="--address=0.0.0.0"
-KUBELET_HOSTNAME="--hostname_override={{ bootstrap_ip }}"
-KUBELET_API_SERVER="--api_servers=http://{{ kubernetes_api_server_host }}:{{ kubernetes_api_server_port }}"
+KUBELET_HOSTNAME="--hostname_override={{ commissaire_bootstrap_ip }}"
+KUBELET_API_SERVER="--api_servers=http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -64,6 +64,17 @@ class OSCmdBase:
         raise NotImplementedError('{0}.upgrade() must be overriden.'.format(
             self.__class__.__name__))
 
+    def install_libselinux_python(self):
+        """
+        Install libselinux_python command. Must be overriden.
+
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        raise NotImplementedError(
+            '{0}.install_libselinux_python() must be overriden.'.format(
+                self.__class__.__name__))
+
     def install_docker(self):
         """
         Install Docker command. Must be overriden.

--- a/src/commissaire/oscmd/atomic.py
+++ b/src/commissaire/oscmd/atomic.py
@@ -45,6 +45,15 @@ class OSCmd(OSCmdBase):
         """
         return ['rpm-ostree', 'upgrade']
 
+    def install_libselinux_python(self):
+        """
+        Atomic install libselinux_python command.
+
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['true']
+
     def install_docker(self):
         """
         Atomic install docker command.

--- a/src/commissaire/oscmd/atomic.py
+++ b/src/commissaire/oscmd/atomic.py
@@ -22,6 +22,15 @@ from commissaire.oscmd import OSCmdBase
 class OSCmd(OSCmdBase):
     """
     Commmands for Atomic.
+
+    .. note::
+
+       install_* methods return true since Atomic already has these
+       packages as part of the OS and does not allow installing packages.
+
+    .. todo::
+
+       TODO: skip install_* commands for atomic via ansible playbook.
     """
 
     #: The type of Operating System
@@ -47,7 +56,7 @@ class OSCmd(OSCmdBase):
 
     def install_libselinux_python(self):
         """
-        Atomic install libselinux_python command.
+        Faux Atomic install libselinux_python command.
 
         :return: The command to execute as a list
         :rtype: list
@@ -56,7 +65,7 @@ class OSCmd(OSCmdBase):
 
     def install_docker(self):
         """
-        Atomic install docker command.
+        Faux Atomic install docker command.
 
         :return: The command to execute as a list
         :rtype: list
@@ -74,7 +83,7 @@ class OSCmd(OSCmdBase):
 
     def install_flannel(self):
         """
-        Atomic install flannel command.
+        Faux Atomic install flannel command.
 
         :return: The command to execute as a list
         :rtype: list
@@ -92,7 +101,7 @@ class OSCmd(OSCmdBase):
 
     def install_kube(self):
         """
-        Atomic install Kube command.
+        Faux Atomic install Kube command.
 
         :return: The command to execute as a list
         :rtype: list

--- a/src/commissaire/oscmd/fedora.py
+++ b/src/commissaire/oscmd/fedora.py
@@ -45,6 +45,15 @@ class OSCmd(OSCmdBase):
         """
         return ['dnf', 'update', '-y']
 
+    def install_libselinux_python(self):
+        """
+        Fedora install libselinux_python command.
+
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['dnf', 'install', '-y', 'libselinux-python']
+
     def install_docker(self):
         """
         Fedora install docker command.

--- a/src/commissaire/oscmd/rhel.py
+++ b/src/commissaire/oscmd/rhel.py
@@ -36,6 +36,15 @@ class OSCmd(OSCmdBase):
         """
         return ['yum', 'update', '-y']
 
+    def install_libselinux_python(self):
+        """
+        RHEL install libselinux_python command.
+
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['yum', 'install', '-y', 'libselinux-python']
+
     def install_docker(self):
         """
         RHEL install Docker command.

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -16,10 +16,7 @@
 Ansible API transport.
 """
 
-import jinja2
 import logging
-import os
-import tempfile
 
 from collections import namedtuple
 from pkg_resources import resource_filename
@@ -139,21 +136,25 @@ class Transport:
         self.loader = DataLoader()
         self.passwords = {}
 
-    def _run(self, ip, key_file, play_source, expected_results=[0]):
+    def _run(self, ips, key_file, play_file,
+             expected_results=[0], play_vars={}):
         """
         Common code used for each run.
 
-        :param ip: IP address to check.
-        :type ip: str
+        :param ips: IP address(es) to check.
+        :type ips: str or list
         :param key_file: Full path the the file holding the private SSH key.
         :type key_file: string
-        :param play_source: Ansible play.
-        :type play_source: dict
+        :param play_file: Path to the ansible play file.
+        :type play_file: str
         :param expected_results: List of expected return codes. Default: [0]
         :type expected_results: list
         :returns: Ansible exit code
         :type: int
         """
+        if type(ips) != list:
+            ips = [ips]
+
         ssh_args = ('-o StrictHostKeyChecking=no -o '
                     'ControlMaster=auto -o ControlPersist=60s')
         options = self.Options(
@@ -167,22 +168,32 @@ class Transport:
         inventory = Inventory(
             loader=self.loader,
             variable_manager=self.variable_manager,
-            host_list=ip)
+            host_list=ips)
         self.logger.debug('Options: {0}'.format(options))
-        # TODO: Fix this ... weird but works
-        group = Group(ip)
-        group.add_host(Host(ip, 22))
-        inventory.groups.update({ip: group})
+
+        group = Group('commissaire_targets')
+        for ip in ips:
+            host = Host(ip, 22)
+            group.add_host(host)
+
+        inventory.groups.update({'commissaire_targets': group})
         self.logger.debug('Inventory: {0}'.format(inventory))
-        # ---
 
         self.variable_manager.set_inventory(inventory)
-        self.logger.debug(
-            'Running play for host {0}: {1}'.format(ip, play_source))
+
+        play_source = self.loader.load_from_file(play_file)[0]
         play = Play().load(
             play_source,
             variable_manager=self.variable_manager,
             loader=self.loader)
+
+        # Add any variables provided into the play
+        play.vars.update(play_vars)
+
+        self.logger.debug(
+            'Running play for hosts {0}: play={1}, vars={2}'.format(
+                ips, play_source, play.vars))
+
         # actually run it
         tqm = None
         try:
@@ -208,57 +219,41 @@ class Transport:
         self.logger.debug('{0}: Bad result {1}'.format(ip, result))
         raise Exception('Can not run for {0}'.format(ip))
 
-    def upgrade(self, ip, key_file, oscmd):
+    def upgrade(self, ips, key_file, oscmd):
         """
         Upgrades a host via ansible.
 
-        :param ip: IP address to upgrade.
-        :type ip: str
+        :param ips: IP address(es) to upgrade.
+        :type ips: str or list
         :param key_file: Full path the the file holding the private SSH key.
         :param oscmd: OSCmd instance to use
         :type oscmd: commissaire.oscmd.OSCmdBase
         :type key_file: str
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
-        # TODO: Use ansible to do multiple hosts...
-        play_source = {
-            'name': 'upgrade',
-            'hosts': ip,
-            'gather_facts': 'no',
-            'tasks': [{
-                'action': {
-                    'module': 'command',
-                    'args': " ".join(oscmd.upgrade())
-                }
-            }]
-        }
-        return self._run(ip, key_file, play_source)
+        play_file = resource_filename(
+            'commissaire', 'data/ansible/playbooks/upgrade.yaml')
+        return self._run(
+            ips, key_file, play_file, [0],
+            {'commissaire_upgrade_command': " ".join(oscmd.upgrade())})
 
-    def restart(self, ip, key_file, oscmd):
+    def restart(self, ips, key_file, oscmd):
         """
         Restarts a host via ansible.
 
-        :param ip: IP address to reboot.
-        :type ip: str
+        :param ips: IP address(es) to restart.
+        :type ips: str or list
         :param key_file: Full path the the file holding the private SSH key.
         :type key_file: str
         :param oscmd: OSCmd instance to use
         :type oscmd: commissaire.oscmd.OSCmdBase
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
-        # TODO: Use ansible to do multiple hosts...
-        play_source = {
-            'name': 'reboot',
-            'hosts': ip,
-            'gather_facts': 'no',
-            'tasks': [{
-                'action': {
-                    'module': 'command',
-                    'args': " ".join(oscmd.restart())
-                }
-            }]
-        }
-        return self._run(ip, key_file, play_source, [0, 2])
+        play_file = resource_filename(
+            'commissaire', 'data/ansible/playbooks/restart.yaml')
+        return self._run(
+            ips, key_file, play_file, [0, 2],
+            {'commissaire_restart_command': " ".join(oscmd.restart())})
 
     def get_info(self, ip, key_file):
         """
@@ -270,15 +265,9 @@ class Transport:
         :type key_file: str
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
-        # create play with tasks
-        play_source = {
-            'name': 'gather',
-            'hosts': ip,
-            'gather_facts': 'yes',
-            'tasks': []
-
-        }
-        result, fact_cache = self._run(ip, key_file, play_source)
+        play_file = resource_filename(
+            'commissaire', 'data/ansible/playbooks/get_info.yaml')
+        result, fact_cache = self._run(ip, key_file, play_file)
         facts = {}
         facts['os'] = fact_cache['ansible_distribution'].lower()
         facts['cpus'] = fact_cache['ansible_processor_cores']
@@ -318,165 +307,53 @@ class Transport:
         :type oscmd: commissaire.oscmd.OSCmdBase
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
-        # TODO: Use ansible to do multiple hosts...
         self.logger.debug('Using {0} as the oscmd class for {1}'.format(
             oscmd.os_type, ip))
 
-        # TODO: I'd love to use ansibles "template" but it, as well as copy
-        # always fails when used in tasks in 2.0.0.2.
-        # Fill out templates
-        tpl_loader = jinja2.loaders.FileSystemLoader(
-            resource_filename('commissaire', 'data/templates/'))
-        tpl_vars = {
-            'bootstrap_ip': ip,
-            'kubernetes_api_server_host': config.kubernetes['uri'].hostname,
-            'kubernetes_api_server_port': config.kubernetes['uri'].port,
-            'kubernetes_bearer_token': config.kubernetes['token'],
-            'docker_registry_host': '127.0.0.1',  # TODO: Where do we get this?
-            'docker_registry_port': 8080,  # TODO: Where do we get this?
-            'etcd_host': config.etcd['uri'].hostname,
-            'etcd_port': config.etcd['uri'].port,
-            'flannel_key': '/atomic01/network'  # TODO: Where do we get this?
+        play_vars = {
+            'commissaire_bootstrap_ip': ip,
+            'commissaire_kubernetes_api_server_host': config.kubernetes.get(
+                'uri').hostname,
+            'commissaire_kubernetes_api_server_port': config.kubernetes.get(
+                'uri').port,
+            'commissaire_kubernetes_bearer_token': config.kubernetes['token'],
+            # TODO: Where do we get this?
+            'commissaire_docker_registry_host': '127.0.0.1',
+            # TODO: Where do we get this?
+            'commissaire_docker_registry_port': 8080,
+            'commissaire_etcd_host': config.etcd['uri'].hostname,
+            'commissaire_etcd_port': config.etcd['uri'].port,
+            # TODO: Where do we get this?
+            'commissaire_flannel_key': '/atomic01/network',
+            'commissaire_docker_config_local': resource_filename(
+                'commissaire', 'data/templates/docker'),
+            'commissaire_flanneld_config_local': resource_filename(
+                'commissaire', 'data/templates/flanneld'),
+            'commissaire_kubelet_config_local': resource_filename(
+                'commissaire', 'data/templates/kubelet'),
+            'commissaire_kube_config_config_local': resource_filename(
+                'commissaire', 'data/templates/kube_config'),
+            'commissaire_kubeconfig_config_local': resource_filename(
+                'commissaire', 'data/templates/kubeconfig'),
+            'commissaire_install_libselinux_python': " ".join(
+                oscmd.install_libselinux_python()),
+            'commissaire_docker_config': oscmd.docker_config,
+            'commissaire_flanneld_config': oscmd.flanneld_config,
+            'commissaire_kubelet_config': oscmd.kubelet_config,
+            'commissaire_kube_config_config': oscmd.kubernetes_config,
+            'commissaire_kubeconfig_config': oscmd.kubernetes_kubeconfig,
+            'commissaire_install_flannel': " ".join(oscmd.install_flannel()),
+            'commissaire_install_docker': " ".join(oscmd.install_docker()),
+            'commissaire_install_kube': " ".join(oscmd.install_kube()),
+            'commissaire_flannel_service': oscmd.flannel_service,
+            'commissaire_docker_service': oscmd.flannel_service,
+            'commissaire_kubelet_service': oscmd.kubelet_service,
+            'commissaire_kubeproxy_service': oscmd.kubelet_proxy_service,
         }
-        self.logger.debug('Variables for bootstrap: {0}'.format(tpl_vars))
-        tpl_env = jinja2.Environment()
-        configs = {}
-        for tpl_name in (
-                'docker', 'flanneld', 'kubelet', 'kube_config', 'kubeconfig'):
-            f = tempfile.NamedTemporaryFile(prefix=tpl_name, delete=False)
-            f.write(tpl_loader.load(tpl_env, tpl_name).render(tpl_vars))
-            f.close()
-            self.logger.debug('Wrote temporary config for {0} at {1}'.format(
-                tpl_name, f.name))
-            configs[tpl_name] = f.name
+        self.logger.debug('Variables for bootstrap: {0}'.format(play_vars))
 
-        play_source = {
-            'name': 'bootstrap',
-            'hosts': ip,
-            'gather_facts': 'no',
-            'tasks': [
-                {
-                    'name': 'Install Flannel',
-                    'action': {
-                        'module': 'command',
-                        'args': " ".join(oscmd.install_flannel()),
-                    }
-                },
-                {
-                    'name': 'Configure Flannel',
-                    'action': {
-                        'module': 'synchronize',
-                        'args': {
-                            'dest': oscmd.flanneld_config,
-                            'src': configs['flanneld'],
-                        }
-                    }
-                },
-                {
-                    'name': 'Enable and Start Flannel',
-                    'action': {
-                        'module': 'service',
-                        'args': {
-                            'name': oscmd.flannel_service,
-                            'enabled': 'yes',
-                            'state': 'started',
-                        }
-                    }
-                },
-                {
-                    'name': 'Install Docker',
-                    'action': {
-                        'module': 'command',
-                        'args': " ".join(oscmd.install_docker()),
-                    }
-                },
-                {
-                    'name': 'Configure Docker',
-                    'action': {
-                        'module': 'synchronize',
-                        'args': {
-                            'dest': oscmd.docker_config,
-                            'src': configs['docker'],
-                        }
-                    }
-                },
-                {
-                    'name': 'Enable and Start Docker',
-                    'action': {
-                        'module': 'service',
-                        'args': {
-                            'name': oscmd.docker_service,
-                            'enabled': 'yes',
-                            'state': 'started',
-                        }
-                    }
-                },
-                {
-                    'name': 'Install Kubernetes Node',
-                    'action': {
-                        'module': 'command',
-                        'args': " ".join(oscmd.install_kube()),
-                    }
-                },
-                {
-                    'name': 'Configure Kubernetes Node',
-                    'action': {
-                        'module': 'synchronize',
-                        'args': {
-                            'dest': oscmd.kubernetes_config,
-                            'src': configs['kube_config'],
-                        }
-                    }
-                },
-                {
-                    'name': 'Add Kubernetes kubeconfig',
-                    'action': {
-                        'module': 'synchronize',
-                        'args': {
-                            'dest': oscmd.kubernetes_kubeconfig,
-                            'src': configs['kubeconfig'],
-                        }
-                    }
-                },
-                {
-                    'name': 'Configure Kubernetes kubelet',
-                    'action': {
-                        'module': 'synchronize',
-                        'args': {
-                            'dest': oscmd.kubelet_config,
-                            'src': configs['kubelet'],
-                        }
-                    }
-                },
-                {
-                    'name': 'Enable and Start Kubelet',
-                    'action': {
-                        'module': 'service',
-                        'args': {
-                            'name': oscmd.kubelet_service,
-                            'enabled': 'yes',
-                            'state': 'started',
-                        }
-                    }
-                },
-                {
-                    'name': 'Enable and Start Kube Proxy',
-                    'action': {
-                        'module': 'service',
-                        'args': {
-                            'name': oscmd.kubelet_proxy_service,
-                            'enabled': 'yes',
-                            'state': 'started',
-                        }
-                    }
-                },
-            ]
-        }
+        play_file = resource_filename(
+            'commissaire', 'data/ansible/playbooks/bootstrap.yaml')
+        results = self._run(ip, key_file, play_file, [0], play_vars)
 
-        results = self._run(ip, key_file, play_source, [0])
-
-        # Clean out the temporary configs
-        map(os.unlink, configs.values())
-        self.logger.debug('Removed the temporary configs at {0}'.format(
-            config.values()))
         return results

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -331,7 +331,7 @@ class Transport:
                 'commissaire', 'data/templates/flanneld'),
             'commissaire_kubelet_config_local': resource_filename(
                 'commissaire', 'data/templates/kubelet'),
-            'commissaire_kube_config_config_local': resource_filename(
+            'commissaire_kubernetes_config_local': resource_filename(
                 'commissaire', 'data/templates/kube_config'),
             'commissaire_kubeconfig_config_local': resource_filename(
                 'commissaire', 'data/templates/kubeconfig'),
@@ -340,7 +340,7 @@ class Transport:
             'commissaire_docker_config': oscmd.docker_config,
             'commissaire_flanneld_config': oscmd.flanneld_config,
             'commissaire_kubelet_config': oscmd.kubelet_config,
-            'commissaire_kube_config_config': oscmd.kubernetes_config,
+            'commissaire_kubernetes_config': oscmd.kubernetes_config,
             'commissaire_kubeconfig_config': oscmd.kubernetes_kubeconfig,
             'commissaire_install_flannel': " ".join(oscmd.install_flannel()),
             'commissaire_install_docker': " ".join(oscmd.install_docker()),

--- a/test/test_oscmd.py
+++ b/test/test_oscmd.py
@@ -26,9 +26,8 @@ class _Test_OSCmd(TestCase):
     """
 
     oscmdcls = None
-    expected_methods = (
-        'restart', 'upgrade', 'install_docker',
-        'install_flannel', 'install_kube')
+    expected_methods = ('restart', 'upgrade', 'install_libselinux_python',
+                        'install_docker', 'install_flannel', 'install_kube')
 
     def before(self):
         """

--- a/test/test_oscmd_atomic.py
+++ b/test/test_oscmd_atomic.py
@@ -16,14 +16,16 @@
 Test cases for the commissaire.oscmd.atomic module.
 """
 
-from . import TestCase
+from . test_oscmd import _Test_OSCmd
 from commissaire.oscmd import atomic
 
 
-class Test_Atomic_OSCmd(TestCase):
+class Test_Atomic_OSCmd(_Test_OSCmd):
     """
     Tests for the OSCmd class for Atomic.
     """
+
+    oscmdcls = atomic.OSCmd
 
     def before(self):
         """
@@ -33,10 +35,8 @@ class Test_Atomic_OSCmd(TestCase):
 
     def test_atomic_oscmd_commands(self):
         """
-        Verify Fedora's OSCmd returns proper data on restart.
+        Verify Atomic's OSCmd returns proper data on restart.
         """
-        for meth in ('restart', 'upgrade', 'install_docker',
-                     'start_docker', 'install_flannel', 'start_flannel',
-                     'install_kube', 'start_kube', 'start_kube_proxy'):
+        for meth in self.expected_methods:
             cmd = getattr(self.instance, meth)()
             self.assertEquals(list, type(cmd))


### PR DESCRIPTION
The will allow easier modification in the future for those who are used to the yaml playbook 

- Added ansible yaml files
- Using ansible template rather than jinja2 directly
- Install libselinux-python if not on remote host
- Removed unused imports
- Removed jinja2 from requirements
