### PR TITLE
fix: Race condition issue in adding host to cluster.

### DIFF
--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -163,7 +163,6 @@ class HostResource(Resource):
 
         host = Host(**host_creation)
         new_host = self.store.set(key, host.to_json(secure=True))
-        INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
 
         # Add host to the requested cluster.
         if cluster_name:
@@ -171,6 +170,7 @@ class HostResource(Resource):
 
         resp.status = falcon.HTTP_201
         req.context['model'] = Host(**json.loads(new_host.value))
+        INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
 
     def on_delete(self, req, resp, address):
         """

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -108,7 +108,10 @@ def etcd_cluster_add_host(store, name, address):
 
     if address not in cluster.hostset:
         cluster.hostset.append(address)
-        store.set(cluster.etcd.key, cluster.to_json(secure=True))
+        r = store.write(
+            cluster.etcd.key,
+            cluster.to_json(secure=True),
+            prevValue=cluster.etcd.value)
 
 
 def etcd_cluster_remove_host(store, name, address):

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -453,6 +453,8 @@ class Test_ClusterSingleHostResource(TestCase):
         self.datasource.get.return_value = self.return_value
         self.datasource.set = MagicMock(name='set')
         self.datasource.set.return_value = self.return_value
+        self.datasource.write = MagicMock(name='set')
+        self.datasource.write.return_value = self.return_value
         self.resource = clusters.ClusterSingleHostResource(self.datasource)
         self.api.add_route(
             '/api/v0/cluster/{name}/hosts/{address}', self.resource)
@@ -498,7 +500,7 @@ class Test_ClusterSingleHostResource(TestCase):
         body = self.simulate_request(
             '/api/v0/cluster/developent/hosts/10.2.0.3', method='PUT')
         self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(1, self.datasource.set.call_count)
+        self.assertEquals(1, self.datasource.write.call_count)
         self.assertEqual(falcon.HTTP_200, self.srmock.status)
         self.assertEqual({}, json.loads(body[0]))
 

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -191,6 +191,8 @@ class Test_HostResource(TestCase):
         self.datasource.delete.return_value = self.return_value
         self.datasource.set = MagicMock(name='set')
         self.datasource.set.return_value = self.return_value
+        self.datasource.write = MagicMock(name='set')
+        self.datasource.write.return_value = self.return_value
         self.resource = hosts.HostResource(self.datasource)
         self.api.add_route('/api/v0/host/{address}', self.resource)
 
@@ -260,7 +262,8 @@ class Test_HostResource(TestCase):
         body = self.simulate_request(
             '/api/v0/host/10.2.0.2', method='PUT', body=data)
         # datasource's set should have been called twice
-        self.assertEquals(2, self.datasource.set.call_count)
+        self.assertEquals(1, self.datasource.set.call_count)
+        self.assertEquals(1, self.datasource.write.call_count)
         self.assertEqual(self.srmock.status, falcon.HTTP_201)
         self.assertEqual(json.loads(self.ahost), json.loads(body[0]))
 


### PR DESCRIPTION
This fixes (or seems to) the issue where the data in the host
gets corrupted due to the ordering of calls. By pushing the
investigater lower in the handler and doing a CAS inside
```util.etcd_cluster_add_host``` the proper flow occurs.

I believe this fixes the problem originally found in #47.