### PR TITLE
Allow e2e/BDD To Start It's Own Services

### DIFF
--- a/doc/examples/run_e2e_bdd_example.rst
+++ b/doc/examples/run_e2e_bdd_example.rst
@@ -1,3 +1,12 @@
+
+.. code-block:: shell
+
+   (virtualenv)$ behave -D start-etcd=true -D start-server=true
+   ...
+
+
+You can also run the tests against any commissaire/etcd instance directly.
+
 .. warning::
 
    Do **not** point to a real instance of commissaire. e2e/BDD tests will

--- a/features/environment.py
+++ b/features/environment.py
@@ -97,8 +97,8 @@ def after_all(context):
     """
     Run after everything finishes.
     """
-    if hasattr(context, 'SERVER_PROCESS'):
-        context.ETCD_PROCESS.kill()
     if hasattr(context, 'ETCD_PROCESS'):
+        context.ETCD_PROCESS.kill()
+    if hasattr(context, 'SERVER_PROCESS'):
         context.SERVER_PROCESS.terminate()
         context.SERVER_PROCESS.wait()

--- a/features/environment.py
+++ b/features/environment.py
@@ -97,8 +97,8 @@ def after_all(context):
     """
     Run after everything finishes.
     """
-    if context.config.userdata.get('start-etcd', None):
+    if hasattr(context, 'SERVER_PROCESS'):
         context.ETCD_PROCESS.kill()
-    if context.config.userdata.get('start-server', None):
+    if hasattr(context, 'ETCD_PROCESS'):
         context.SERVER_PROCESS.terminate()
         context.SERVER_PROCESS.wait()

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -28,7 +28,7 @@ import etcd
 import falcon
 import gevent
 
-from gevent.pywsgi import WSGIServer, LoggingLogAdapter
+from gevent.pywsgi import WSGIServer, LoggingLogAdapter, socket
 
 from commissaire.compat.urlparser import urlparse
 from commissaire.compat import exception
@@ -214,6 +214,9 @@ def main():  # pragma: no cover
         gevent.signal.signal(
             gevent.signal._signal.SIGTERM, lambda s, f: server.stop())
         server.serve_forever()
+    except socket.error:
+        _, ex, _ = exception.raise_if_not(socket.error)
+        logging.fatal(ex)
     except KeyboardInterrupt:
         pass
 

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -207,7 +207,13 @@ def main():  # pragma: no cover
         }
         kwargs.update(ssl_args)
         logging.debug('WSGIServer args: {0}'.format(kwargs))
-        WSGIServer(**kwargs).serve_forever()
+
+        server = WSGIServer(**kwargs)
+
+        # Catch SIGTERM and stop the server.
+        gevent.signal.signal(
+            gevent.signal._signal.SIGTERM, lambda s, f: server.stop())
+        server.serve_forever()
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
The e2e/BDD can now run commissaire and/or etcd services through behave arguments.

The SIGTERM commit was required for gracefully stopping the server else there would be a chance of orphaned process(es) left behind.