### PR TITLE
Monkeying around with OSCmdBase

### DIFF
--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -84,7 +84,7 @@ def clusterexec(cluster_name, command, store):
             continue  # Move on to the next one
         oscmd = get_oscmd(a_host['os'])
 
-        command_list = getattr(oscmd(), command)()  # Only used for logging
+        command_list = getattr(oscmd, command)()  # Only used for logging
         logger.info('Executing {0} on {1}...'.format(
             command_list, a_host['address']))
 
@@ -105,7 +105,7 @@ def clusterexec(cluster_name, command, store):
 
         transport = ansibleapi.Transport()
         result, facts = getattr(transport, command)(
-            a_host['address'], key_file, oscmd())
+            a_host['address'], key_file, oscmd)
         try:
             f.unlink(key_file)
             logger.debug('Removed temporary key file {0}'.format(key_file))

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -112,7 +112,7 @@ def investigator(queue, config, store, run_once=False):
             address, data))
 
         logger.info('{0} is now in bootstrapping'.format(address))
-        oscmd = get_oscmd(data['os'])()
+        oscmd = get_oscmd(data['os'])
         try:
             result, facts = transport.bootstrap(
                 address, key_file, config, oscmd)

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -44,27 +44,30 @@ class OSCmdBase:
     #: Kubernetes kube-proxy service name
     kubelet_proxy_service = 'kube-proxy'
 
-    def restart(self):
+    @classmethod
+    def restart(cls):
         """
         Restart command. Must be overriden.
 
         :return: The command to execute as a list
         :rtype: list
         """
-        raise NotImplementedError('{0}.restart() must be overriden.'.format(
-            self.__class__.__name__))
+        raise NotImplementedError(
+            '{0}.restart() must be overriden.'.format(cls.__name__))
 
-    def upgrade(self):
+    @classmethod
+    def upgrade(cls):
         """
         Upgrade command. Must be overriden.
 
         :return: The command to execute as a list
         :rtype: list
         """
-        raise NotImplementedError('{0}.upgrade() must be overriden.'.format(
-            self.__class__.__name__))
+        raise NotImplementedError(
+            '{0}.upgrade() must be overriden.'.format(cls.__name__))
 
-    def install_libselinux_python(self):
+    @classmethod
+    def install_libselinux_python(cls):
         """
         Install libselinux_python command. Must be overriden.
 
@@ -73,9 +76,10 @@ class OSCmdBase:
         """
         raise NotImplementedError(
             '{0}.install_libselinux_python() must be overriden.'.format(
-                self.__class__.__name__))
+                cls.__name__))
 
-    def install_docker(self):
+    @classmethod
+    def install_docker(cls):
         """
         Install Docker command. Must be overriden.
 
@@ -83,10 +87,10 @@ class OSCmdBase:
         :rtype: list
         """
         raise NotImplementedError(
-            '{0}.install_docker() must be overriden.'.format(
-                self.__class__.__name__))
+            '{0}.install_docker() must be overriden.'.format(cls.__name__))
 
-    def install_flannel(self):
+    @classmethod
+    def install_flannel(cls):
         """
         Install Flannel command. Must be overriden.
 
@@ -94,10 +98,10 @@ class OSCmdBase:
         :rtype: list
         """
         raise NotImplementedError(
-            '{0}.install_flannel() must be overriden.'.format(
-                self.__class__.__name__))
+            '{0}.install_flannel() must be overriden.'.format(cls.__name__))
 
-    def install_kube(self):
+    @classmethod
+    def install_kube(cls):
         """
         Install Kube command. Must be overriden.
 
@@ -105,8 +109,7 @@ class OSCmdBase:
         :rtype: list
         """
         raise NotImplementedError(
-            '{0}.install_kube() must be overriden.'.format(
-                self.__class__.__name__))
+            '{0}.install_kube() must be overriden.'.format(cls.__name__))
 
 
 def get_oscmd(os_type):

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -17,10 +17,43 @@ Abstraction of commands that change across operating systems.
 """
 
 
+class OSCmdBaseMeta(type):
+    """
+    Meta-class for OSCmdBase.
+    """
+
+    def __init__(self, *args):
+        """
+        Gives the class a unique 'extra' command dictionary.
+
+        The 'extra' dictionary keys are strings that identify the purpose
+        of a sequence of commands.  The same keys can be used in multiple
+        subclasses to identify extra commands with a common purpose.
+
+        The 'extra' dictionary values are tuples of command lists.
+
+        For example:
+
+        cls.extra['enablerepos'] = (
+           ['yum-config-manager', '--enable', 'repo1'],
+           ['yum-config-manager', '--enable', 'repo2'])
+
+        Elsewhere, at a point where repos should be enabled:
+
+        for cmd in oscmd.extra.get('enablerepos', ()):
+           # Execute cmd
+        """
+        def __init__(self, *args):
+            super(OSCmdBaseMeta, self).__init__(*args)
+            self.extra = {}
+
+
 class OSCmdBase:
     """
     Operating system command abstraction.
     """
+
+    __metaclass__ = OSCmdBaseMeta
 
     #: The type of Operating System
     os_type = None

--- a/src/commissaire/oscmd/atomic.py
+++ b/src/commissaire/oscmd/atomic.py
@@ -36,7 +36,8 @@ class OSCmd(OSCmdBase):
     #: The type of Operating System
     os_type = 'atomic'
 
-    def restart(self):
+    @classmethod
+    def restart(cls):
         """
         Atomic restart command.
 
@@ -45,7 +46,8 @@ class OSCmd(OSCmdBase):
         """
         return ['systemctl', 'reboot']
 
-    def upgrade(self):
+    @classmethod
+    def upgrade(cls):
         """
         Atomic upgrade command.
 
@@ -54,7 +56,8 @@ class OSCmd(OSCmdBase):
         """
         return ['rpm-ostree', 'upgrade']
 
-    def install_libselinux_python(self):
+    @classmethod
+    def install_libselinux_python(cls):
         """
         Faux Atomic install libselinux_python command.
 
@@ -63,7 +66,8 @@ class OSCmd(OSCmdBase):
         """
         return ['true']
 
-    def install_docker(self):
+    @classmethod
+    def install_docker(cls):
         """
         Faux Atomic install docker command.
 
@@ -72,7 +76,8 @@ class OSCmd(OSCmdBase):
         """
         return ['true']
 
-    def install_flannel(self):
+    @classmethod
+    def install_flannel(cls):
         """
         Faux Atomic install flannel command.
 
@@ -81,7 +86,8 @@ class OSCmd(OSCmdBase):
         """
         return ['true']
 
-    def install_kube(self):
+    @classmethod
+    def install_kube(cls):
         """
         Faux Atomic install Kube command.
 

--- a/src/commissaire/oscmd/fedora.py
+++ b/src/commissaire/oscmd/fedora.py
@@ -27,7 +27,8 @@ class OSCmd(OSCmdBase):
     #: The type of Operating System
     os_type = 'fedora'
 
-    def restart(self):
+    @classmethod
+    def restart(cls):
         """
         Fedora restart command.
 
@@ -36,7 +37,8 @@ class OSCmd(OSCmdBase):
         """
         return ['systemctl', 'reboot']
 
-    def upgrade(self):
+    @classmethod
+    def upgrade(cls):
         """
         Fedora upgrade command.
 
@@ -45,7 +47,8 @@ class OSCmd(OSCmdBase):
         """
         return ['dnf', 'update', '-y']
 
-    def install_libselinux_python(self):
+    @classmethod
+    def install_libselinux_python(cls):
         """
         Fedora install libselinux_python command.
 
@@ -54,7 +57,8 @@ class OSCmd(OSCmdBase):
         """
         return ['dnf', 'install', '-y', 'libselinux-python']
 
-    def install_docker(self):
+    @classmethod
+    def install_docker(cls):
         """
         Fedora install docker command.
 
@@ -63,7 +67,8 @@ class OSCmd(OSCmdBase):
         """
         return ['dnf', 'install', '-y', 'docker']
 
-    def install_flannel(self):
+    @classmethod
+    def install_flannel(cls):
         """
         Fedora install flannel command.
 
@@ -72,7 +77,8 @@ class OSCmd(OSCmdBase):
         """
         return ['dnf', 'install', '-y', 'flannel']
 
-    def install_kube(self):
+    @classmethod
+    def install_kube(cls):
         """
         Fedora install Kube command.
 

--- a/src/commissaire/oscmd/rhel.py
+++ b/src/commissaire/oscmd/rhel.py
@@ -27,7 +27,8 @@ class OSCmd(OSCmdBase):
     #: The type of Operating System
     os_type = 'rhel'
 
-    def upgrade(self):
+    @classmethod
+    def upgrade(cls):
         """
         RHEL upgrade command.
 
@@ -36,7 +37,8 @@ class OSCmd(OSCmdBase):
         """
         return ['yum', 'update', '-y']
 
-    def install_libselinux_python(self):
+    @classmethod
+    def install_libselinux_python(cls):
         """
         RHEL install libselinux_python command.
 
@@ -45,7 +47,8 @@ class OSCmd(OSCmdBase):
         """
         return ['yum', 'install', '-y', 'libselinux-python']
 
-    def install_docker(self):
+    @classmethod
+    def install_docker(cls):
         """
         RHEL install Docker command.
 
@@ -54,7 +57,8 @@ class OSCmd(OSCmdBase):
         """
         return ['yum', 'install', '-y', 'docker']
 
-    def install_kube(self):
+    @classmethod
+    def install_kube(cls):
         """
         RHEL start Kube command.
 
@@ -63,7 +67,8 @@ class OSCmd(OSCmdBase):
         """
         return ['yum', 'install', '-y', 'kubernetes-node']
 
-    def install_flannel(self):
+    @classmethod
+    def install_flannel(cls):
         """
         Atomic install flannel command.
 

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -226,7 +226,7 @@ class Transport:
         :param ips: IP address(es) to upgrade.
         :type ips: str or list
         :param key_file: Full path the the file holding the private SSH key.
-        :param oscmd: OSCmd instance to use
+        :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
         :type key_file: str
         :returns: tuple -- (exitcode(int), facts(dict)).
@@ -245,7 +245,7 @@ class Transport:
         :type ips: str or list
         :param key_file: Full path the the file holding the private SSH key.
         :type key_file: str
-        :param oscmd: OSCmd instance to use
+        :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
@@ -303,7 +303,7 @@ class Transport:
         :type key_file: str
         :param config: Configuration information.
         :type config: commissaire.config.Config
-        :param oscmd: OSCmd instance to useS
+        :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
         :returns: tuple -- (exitcode(int), facts(dict)).
         """


### PR DESCRIPTION
This isn't a real pull request yet.  Just wanted to run a couple ideas by you related to allowing extra commands in `oscmd`.

The first commit is a simplification of sorts.  Since none of the `oscmd` classes have instance data I converted all the methods to `@classmethod` so we don't have to instantiate these things.

The second commit is a simple hack for tacking on extra commands.  I'm not sure exactly how this enhancement is meant to be used so it's kind of a guess.