### PR TITLE
Enable pkg repos on rhel during bootstrapping.

### DIFF
--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -3,6 +3,8 @@
   hosts: commissaire_targets
   gather_facts: no
   tasks:
+    - name: Enable Package Repositories
+      command: "{{ commissaire_enable_pkg_repos }}"
     - name: Install libselinux-python
       command: "{{ commissaire_install_libselinux_python }}"
     - name: Install Flannel

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -350,6 +350,23 @@ class Transport:
             'commissaire_kubelet_service': oscmd.kubelet_service,
             'commissaire_kubeproxy_service': oscmd.kubelet_proxy_service,
         }
+
+        # XXX: Need to enable some package repositories for OS 'rhel'
+        #      (or 'redhat').  This is a hack for a single corner case.
+        #      We discussed how to generalize future cases where we need
+        #      extra commands for a specific OS but decided to defer until
+        #      more crop up.
+        #
+        #      See https://github.com/projectatomic/commissaire/pull/56
+        #
+        if oscmd.os_type in ('rhel', 'redhat'):
+            play_vars['commissaire_enable_pkg_repos'] = (
+                'subscription-manager repos '
+                '--enable=rhel-7-server-extras-rpms '
+                '--enable=rhel-7-server-optional-rpms')
+        else:
+            play_vars['commissaire_enable_pkg_repos'] = 'true'
+
         self.logger.debug('Variables for bootstrap: {0}'.format(play_vars))
 
         play_file = resource_filename(

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,6 +17,8 @@ import os
 
 from falcon.testing import TestBase
 
+# Keep this list synchronized with oscmd modules.
+available_os_types = ('atomic', 'fedora', 'redhat', 'rhel')
 
 def get_fixture_file_path(filename):
     """


### PR DESCRIPTION
This was easy enough to hack in, but I don't know how to test it short of running it on a full test infrastructure.  Any suggestions?

Also CC: @cooktheryan 