### PR TITLE
Certificates can be used for accessing etcd and Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM fedora
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
-ENV MHM_RELEASE v0.0.1rc1
+ENV MHM_RELEASE v0.0.1rc2
 ENV PYTHONPATH  /commissaire/src/
+ENV EXTRA_ARGS  ""
 
 # Install required dependencies and commissaire
 RUN dnf -y update && dnf -y install --setopt=tsflags=nodocs rsync openssh-clients redhat-rpm-config python-pip python-virtualenv git gcc libffi-devel ; dnf clean all && \
@@ -17,4 +18,4 @@ dnf remove -y gcc git redhat-rpm-config libffi-devel && dnf clean all
 
 EXPOSE 8000
 WORKDIR /commissaire
-CMD . /environment/bin/activate && python src/commissaire/script.py -e ${ETCD} -k ${KUBE}
+CMD . /environment/bin/activate && python src/commissaire/script.py -e ${ETCD} -k ${KUBE} ${EXTRA_ARGS}

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -71,13 +71,23 @@ commissaire_kubeproxy_service                 Name of the kubernetes proxy servi
 commissaire_restart_command                   Host restart command
 commissaire_upgrade_command                   Host upgrade command
 commissaire_bootstrap_ip                      The IP address of the host
+commissaire_kubernetes_api_server_scheme      The kubernetes api server scheme (http/https)
 commissaire_kubernetes_api_server_host        The kubernetes api server host
 commissaire_kubernetes_api_server_port        The kubernetes api server port
+commissaire_kubernetes_client_cert_path       Path to the kubernetes client certificate
+commissaire_kubernetes_client_key_path        Path to the kubernetes client key
+commissaire_kubernetes_client_cert_path_local Path to the local kubernetes client certificate
+commissaire_kubernetes_client_key_path_local  Path to the local kubernetes client key
 commissaire_kubernetes_bearer_token           The bearer token used to contact kubernetes
 commissaire_docker_registry_host              The docker registry host
 commissaire_docker_registry_port              The docker registry port
+commissaire_etcd_scheme                       The etcd server scheme (http/https)
 commissaire_etcd_host                         The etcd host
 commissaire_etcd_port                         The etcd port
+commissaire_etcd_client_cert_path             Path to the etcd client certificate
+commissaire_etcd_client_key_path              Path to the etcd client key
+commissaire_etcd_client_cert_path_local       Path to the local etcd client certificate
+commissaire_etcd_client_key_path_local        Path to the local etcd client key
 commissaire_flannel_key                       The flannel configuration key
 ============================================= ======================================================
 

--- a/doc/examples/etcd_set_kube_client_side_certificate.rst
+++ b/doc/examples/etcd_set_kube_client_side_certificate.rst
@@ -1,0 +1,6 @@
+.. code-block:: shell
+
+   (virtualenv)$ etcdctl set '/commissaire/config/kube_certificate_path' $PATH_TO_CRT_FILE
+   ...
+   (virtualenv)$ etcdctl set '/commissaire/config/kube_certificate_key_path' $PATH_TO_KEY_FILE
+   ...

--- a/doc/examples/run_from_source.rst
+++ b/doc/examples/run_from_source.rst
@@ -1,4 +1,7 @@
+
 .. code-block:: shell
 
-   (virtualenv)$ PYTHONPATH=`pwd`/src python src/commissaire/script.py -e http://127.0.0.1:2379 -k http://127.0.0.1:8080 &
+   (virtualenv)$ PYTHONPATH=`pwd`/src python src/commissaire/script.py \
+       --etcd-uri http://127.0.0.1:2379 \
+       --kube-uri http://127.0.0.1:8080 &
    ...

--- a/doc/examples/run_from_source_more_secure.rst
+++ b/doc/examples/run_from_source_more_secure.rst
@@ -1,0 +1,14 @@
+.. note::
+
+   Using client side certificates to access etcd/kubernetes will require proper configuration within etcd/kubernetes.
+
+.. code-block:: shell
+
+   (virtualenv)$ PYTHONPATH=`pwd`/src python src/commissaire/script.py  \
+       --kube-uri https://127.0.0.1:8080 \
+       --tls-keyfile /path/to/server.key \
+       --tls-certificate /path/to/server.crt \
+       --etcd-uri https://127.0.0.1:2379
+       --etcd-cert-path /path/to/etcd_clientside.crt \
+       --etcd-cert-key-path /path/to/etcd_clientside.key &
+   ...

--- a/doc/examples/run_via_docker_more_secure.rst
+++ b/doc/examples/run_via_docker_more_secure.rst
@@ -1,0 +1,9 @@
+.. code-block:: shell
+
+    docker run -d \
+        -v /path/to/etcd/certificates:/certs \
+        -e ETCD=https://127.0.0.1:2379 \
+        -e KUBE=https://127.0.0.1:8080 \
+        -e EXTRA_ARGS="--tls-certfile /certs/server.crt --tls-keyfile /certs/server.key --etcd-cert-path /certs/etcd.crt --etcd-cert-key-path /certs/etcd.key" \
+        docker.io/commissaire/amhm
+    ...

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -74,13 +74,28 @@ From Source
 ```````````
 From the repo root...
 
+**Not So Secure Mode**
+
 .. include:: examples/run_from_source.rst
+
+**More Secure Mode**
+
+.. include:: examples/run_from_source_more_secure.rst
+
 
 Via Docker
 ``````````
 To run the image specify the ETCD and KUBE variables pointing towards the specific services.
 
+**Not So Secure Mode**
+
 .. include:: examples/run_via_docker.rst
+
+
+**More Secure Mode**
+
+.. include:: examples/run_via_docker_more_secure.rst
+
 
 Adding a Cluster
 ~~~~~~~~~~~~~~~~

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -35,13 +35,27 @@ commissaire will default back to the local files but using Etcd is where configu
 .. include:: examples/etcd_logging_example.rst
 
 
-Set The Kubernetes Bearer Token
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You'll also need to set the kubernetes bearer token in etcd.
+(Recommended) Set The Kubernetes Access Method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bearer Token
+````````````
+
+To use a Bearer token:
 
 .. note:: There is no default for the bearer token!
 
 .. include:: examples/etcd_set_kube_bearer_token.rst
+
+
+Client Certificate
+``````````````````
+
+To use a client certificate:
+
+.. note:: There is no default for the client certificate!
+
+.. include:: examples/etcd_set_kube_client_side_certificate.rst
 
 
 (Optional): Build Docker Container

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -34,15 +34,29 @@ class ContainerManager(ContainerManagerBase):
         :type config: commissaire.config.Config
         """
         ContainerManagerBase.__init__(self)
+        self.scheme = config.kubernetes['uri'].scheme
         self.host = config.kubernetes['uri'].hostname
         self.port = config.kubernetes['uri'].port
         self.con = requests.Session()
-        token = config.kubernetes['token']
-        self.con.headers["Authorization"] = "Bearer {0}".format(token)
+        if config.kubernetes.get('token', None):
+            token = config.kubernetes['token']
+            self.con.headers["Authorization"] = "Bearer {0}".format(token)
+            self.logger.info('Using bearer token')
+            self.logger.debug('Bearer token: {0}'.format(token))
+        if (config.kubernetes.get('certificate_path', None) and
+                config.kubernetes.get('certificate_key_path', None)):
+            certificate_path = config.kubernetes['certificate_path']
+            certificate_key_path = config.kubernetes['certificate_key_path']
+            self.con.cert = (certificate_path, certificate_key_path)
+            self.logger.info(
+                'Using client side certificate. Certificate path: {0} '
+                'Certificate Key Path: {1}'.format(
+                    certificate_path, certificate_key_path))
+
         # TODO: Verify TLS!!!
         self.con.verify = False
-        self.base_uri = 'http://{0}:{1}/api/v1'.format(
-            self.host, self.port)
+        self.base_uri = '{0}://{1}:{2}/api/v1'.format(
+            self.scheme, self.host, self.port)
         self.logger.info('Kubernetes Container Manager created: {0}'.format(
             self.base_uri))
         self.logger.debug(

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -38,15 +38,15 @@ class ContainerManager(ContainerManagerBase):
         self.host = config.kubernetes['uri'].hostname
         self.port = config.kubernetes['uri'].port
         self.con = requests.Session()
-        if config.kubernetes.get('token', None):
-            token = config.kubernetes['token']
+        token = config.kubernetes.get('token', None)
+        if token:
             self.con.headers["Authorization"] = "Bearer {0}".format(token)
             self.logger.info('Using bearer token')
             self.logger.debug('Bearer token: {0}'.format(token))
-        if (config.kubernetes.get('certificate_path', None) and
-                config.kubernetes.get('certificate_key_path', None)):
-            certificate_path = config.kubernetes['certificate_path']
-            certificate_key_path = config.kubernetes['certificate_key_path']
+
+        certificate_path = config.kubernetes.get('certificate_path')
+        certificate_key_path = config.kubernetes.get('certificate_key_path')
+        if certificate_path and certificate_key_path:
             self.con.cert = (certificate_path, certificate_key_path)
             self.logger.info(
                 'Using client side certificate. Certificate path: {0} '

--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -14,6 +14,16 @@
         src: "{{ commissaire_flanneld_config_local }}"
         dest: "{{ commissaire_flanneld_config }}"
         force: yes
+    - name: Add Etcd Client Side Certificate
+      copy:
+        dest: "{{ commissaire_etcd_client_cert_path }}"
+        src: "{{ commissaire_etcd_client_cert_path_local }}"
+      when: "{{ commissaire_etcd_use_cert }}"
+    - name: Add Etcd Client Side Key
+      copy:
+        dest: "{{ commissaire_etcd_client_key_path }}"
+        src: "{{ commissaire_etcd_client_key_path_local }}"
+      when: "{{ commissaire_etcd_use_cert }}"
     - name: Install Docker
       command: "{{ commissaire_install_docker }}"
     - name: Configure Docker
@@ -25,9 +35,19 @@
       command: "{{ commissaire_install_kube }}"
     - name: Configure Kubernetes Node
       template:
-        dest: "{{ commissaire_kube_config_config }}"
-        src: "{{ commissaire_kube_config_config_local }}"
+        dest: "{{ commissaire_kubernetes_config }}"
+        src: "{{ commissaire_kubernetes_config_local }}"
         force: yes
+    - name: Add Kubernetes Client Side Certificate
+      copy:
+        dest: "{{ commissaire_kubernetes_client_cert_path }}"
+        src: "{{ commissaire_kubernetes_client_cert_path_local }}"
+      when: "{{ commissaire_kubernetes_use_cert }}"
+    - name: Add Kubernetes Client Side Key
+      copy:
+        dest: "{{ commissaire_kubernetes_client_key_path }}"
+        src: "{{ commissaire_kubernetes_client_key_path_local }}"
+      when: "{{ commissaire_kubernetes_use_cert }}"
     - name: Add Kubernetes kubeconfig
       template:
         dest: "{{ commissaire_kubeconfig_config }}"

--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,2 +1,4 @@
-FLANNEL_ETCD="http://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
+FLANNEL_ETCD="{{ commissaire_etcd_scheme }}://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
+{%- if commissaire_etcd_use_cert %}
+FLANNEL_OPTIONS="--remote-keyfile={{ commissaire_etcd_client_key_path }} --remote-certfile={{ commissaire_etcd_client_cert_path }}"{% endif %}

--- a/src/commissaire/data/templates/kube_config
+++ b/src/commissaire/data/templates/kube_config
@@ -1,1 +1,1 @@
-KUBE_MASTER="--master=http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"
+KUBE_MASTER="--master={{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"

--- a/src/commissaire/data/templates/kubeconfig
+++ b/src/commissaire/data/templates/kubeconfig
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
     api-version: v1
     insecure-skip-tls-verify: true
-    server: http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}
+    server: {{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}
   name: cluster
 contexts:
 - context:
@@ -16,4 +16,9 @@ preferences:
 users:
 - name: commissairenode
   user:
-    token: {{ commissaire_kubernetes_bearer_token }}
+{%- if commissaire_kubernetes_use_cert %}
+    token: {{ commissaire_kubernetes_bearer_token }}{% endif %}
+{%- if commissaire_kubernetes_client_cert_path|default(false, true) %}
+    client-certificate: {{ commissaire_kubernetes_client_cert_path }}{% endif %}
+{%- if commissaire_kubernetes_use_cert %}
+    client-key: {{ commissaire_kubernetes_client_key_path }}{% endif %}

--- a/src/commissaire/data/templates/kubelet
+++ b/src/commissaire/data/templates/kubelet
@@ -1,3 +1,3 @@
 KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_HOSTNAME="--hostname_override={{ commissaire_bootstrap_ip }}"
-KUBELET_API_SERVER="--api_servers=http://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"
+KUBELET_API_SERVER="--api_servers={{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -34,6 +34,14 @@ class OSCmdBase:
     kubernetes_kubeconfig = '/var/lib/kubelet/kubeconfig'
     #: Full path to kubelet configuration file
     kubelet_config = '/etc/kubernetes/kubelet'
+    #: Full path to the kubernetes client certificate
+    kube_client_cert = '/etc/kubernetes/client.crt'
+    #: Full path to the kubernetes client key
+    kube_client_key = '/etc/kubernetes/client.key'
+    #: Full path to the etcd client certificate
+    etcd_client_cert = '/etc/etcd/client.crt'
+    #: Full path to the etcd client key
+    etcd_client_key = '/etc/etcd/key.crt'
 
     #: Docker service name
     docker_service = 'docker'

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -311,16 +311,22 @@ class Transport:
             oscmd.os_type, ip))
 
         play_vars = {
+            'commissaire_etcd_use_cert': False,
+            'commissaire_kubernetes_use_cert': False,
             'commissaire_bootstrap_ip': ip,
+            'commissaire_kubernetes_api_server_scheme': config.kubernetes.get(
+                'uri').scheme,
             'commissaire_kubernetes_api_server_host': config.kubernetes.get(
                 'uri').hostname,
             'commissaire_kubernetes_api_server_port': config.kubernetes.get(
                 'uri').port,
-            'commissaire_kubernetes_bearer_token': config.kubernetes['token'],
+            'commissaire_kubernetes_bearer_token': config.kubernetes.get(
+                'token', ''),
             # TODO: Where do we get this?
             'commissaire_docker_registry_host': '127.0.0.1',
             # TODO: Where do we get this?
             'commissaire_docker_registry_port': 8080,
+            'commissaire_etcd_scheme': config.etcd['uri'].scheme,
             'commissaire_etcd_host': config.etcd['uri'].hostname,
             'commissaire_etcd_port': config.etcd['uri'].port,
             # TODO: Where do we get this?
@@ -350,6 +356,31 @@ class Transport:
             'commissaire_kubelet_service': oscmd.kubelet_service,
             'commissaire_kubeproxy_service': oscmd.kubelet_proxy_service,
         }
+
+        # Client Certificate additions
+        if config.etcd.get('certificate_path', None):
+            self.logger.info('Using etcd client certs')
+            play_vars['commissaire_etcd_client_cert_path'] = (
+                oscmd.etcd_client_cert)
+            play_vars['commissaire_etcd_client_cert_path_local'] = (
+                config.etcd['certificate_path'])
+            play_vars['commissaire_etcd_client_key_path'] = (
+                oscmd.etcd_client_key)
+            play_vars['commissaire_etcd_client_key_path_local'] = (
+                config.etcd['certificate_key_path'])
+            play_vars['commissaire_etcd_use_cert'] = True
+
+        if config.kubernetes.get('certificate_path', None):
+            self.logger.info('Using kubernetes client certs')
+            play_vars['commissaire_kubernetes_client_cert_path'] = (
+                oscmd.kube_client_cert)
+            play_vars['commissaire_kubernetes_client_cert_path_local'] = (
+                config.kubernetes['certificate_path'])
+            play_vars['commissaire_kubernetes_client_key_path'] = (
+                oscmd.kube_client_key)
+            play_vars['commissaire_kubernetes_client_key_path_local'] = (
+                config.kubernetes['certificate_key_path'])
+            play_vars['commissaire_kubernetes_use_cert'] = True
 
         # XXX: Need to enable some package repositories for OS 'rhel'
         #      (or 'redhat').  This is a hack for a single corner case.


### PR DESCRIPTION
- Kubernetes client now can use a client side certificate path via etcd
- Kubernetes client can now access Kubernetes over TLS
- Etcd client can now use a client side certificate via CLI arguments
- Etcd client can now access Etcd over TLS
- Investigator now creates it's own Etcd connection within it's own process
- Dockerfile update to allow ```EXTRA_ARGS```
