### PR TITLE
Add new endpoint for joining a cluster

### DIFF
--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -313,6 +313,13 @@ Creates a new host record.
 .. note::
    The rest of the host record will be filled out once the data has been pulled from the cluster host.
 
+.. note::
+   As a convenience to hosts wishing to add themselves as part of a boot
+   script, the endpoint /api/v0/host (without the {IP}) also accepts PUT
+   requests.  Here, the host address is inferred from the request itself
+   but otherwise works the same: creates a new host record accessible at
+   /api/v0/host/{IP}.
+
 Example
 ~~~~~~~
 

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -38,7 +38,8 @@ from commissaire.handlers.clusters import (
     ClustersResource, ClusterResource,
     ClusterHostsResource, ClusterSingleHostResource,
     ClusterRestartResource, ClusterUpgradeResource)
-from commissaire.handlers.hosts import HostsResource, HostResource
+from commissaire.handlers.hosts import (
+    HostsResource, HostResource, ImplicitHostResource)
 from commissaire.handlers.status import StatusResource
 from commissaire.queues import INVESTIGATE_QUEUE
 from commissaire.jobs import POOLS, PROCS
@@ -90,6 +91,7 @@ def create_app(
         '/api/v0/cluster/{name}/upgrade',
         ClusterUpgradeResource(store, None))
     app.add_route('/api/v0/clusters', ClustersResource(store, None))
+    app.add_route('/api/v0/host', ImplicitHostResource(store, None))
     app.add_route('/api/v0/host/{address}', HostResource(store, None))
     app.add_route('/api/v0/hosts', HostsResource(store, None))
     return app

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -304,3 +304,96 @@ class Test_HostResource(TestCase):
         self.assertEquals(0, self.datasource.set.call_count)
         self.assertEqual(self.srmock.status, falcon.HTTP_409)
         self.assertEqual({}, json.loads(body[0]))
+
+
+class Test_ImplicitHostResource(TestCase):
+    """
+    Tests for the ImplicitHost Resource.
+    """
+
+    ahost = ('{"address": "127.0.0.1",'
+             ' "status": "available", "os": "atomic",'
+             ' "cpus": 2, "memory": 11989228, "space": 487652,'
+             ' "last_check": "2015-12-17T15:48:18.710454"}')
+
+    etcd_host = ('{"address": "127.0.0.1", "ssh_priv_key": "dGVzdAo=",'
+                 ' "status": "available", "os": "atomic",'
+                 ' "cpus": 2, "memory": 11989228, "space": 487652,'
+                 ' "last_check": "2015-12-17T15:48:18.710454"}')
+
+    etcd_cluster = '{"status": "ok", "hostset": []}'
+
+    etcd_cluster_with_host = '{"status": "ok", "hostset": ["127.0.0.1"]}'
+
+    def before(self):
+        self.api = falcon.API(middleware = [JSONify()])
+        self.datasource = etcd.Client()
+        self.return_value = MagicMock(etcd.EtcdResult)
+        self.datasource.get = MagicMock(name='get')
+        self.datasource.get.return_value = self.return_value
+        self.datasource.delete = MagicMock(name='delete')
+        self.datasource.delete.return_value = self.return_value
+        self.datasource.set = MagicMock(name='set')
+        self.datasource.set.return_value = self.return_value
+        self.datasource.write = MagicMock(name='set')
+        self.datasource.write.return_value = self.return_value
+        self.resource = hosts.ImplicitHostResource(self.datasource)
+        self.api.add_route('/api/v0/host', self.resource)
+
+    def test_implicit_host_create(self):
+        """
+        Verify creation of a Host with an implied address.
+        """
+
+        self.datasource.get.side_effect = (
+            etcd.EtcdKeyNotFound,
+            MagicMock(value=self.etcd_cluster),
+            MagicMock(value=self.etcd_cluster))
+        self.return_value.value = self.etcd_host
+        data = ('{"ssh_priv_key": "dGVzdAo=",'
+                ' "cluster": "testing"}')
+        body = self.simulate_request(
+            '/api/v0/host', method='PUT', body=data)
+        # datasource's set should have been called twice
+        self.assertEquals(1, self.datasource.set.call_count)
+        self.assertEquals(1, self.datasource.write.call_count)
+        self.assertEqual(self.srmock.status, falcon.HTTP_201)
+        self.assertEqual(json.loads(self.ahost), json.loads(body[0]))
+
+        # Make sure creation fails if the cluster doesn't exist
+        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
+        self.datasource.get.reset_mock()
+        self.datasource.set.reset_mock()
+        body = self.simulate_request(
+            '/api/v0/host', method='PUT', body=data)
+        # datasource's set should not have been called
+        self.assertEquals(0, self.datasource.set.call_count)
+        self.assertEqual(self.srmock.status, falcon.HTTP_409)
+        self.assertEqual({}, json.loads(body[0]))
+
+        # Make sure creation is idempotent if the request parameters
+        # agree with an existing host.
+        self.datasource.get.side_effect = (
+            MagicMock(value=self.etcd_host),
+            MagicMock(value=self.etcd_cluster_with_host))
+        self.datasource.get.reset_mock()
+        self.datasource.set.reset_mock()
+        body = self.simulate_request(
+            '/api/v0/host', method='PUT', body=data)
+        # datasource's set should not have been called
+        self.assertEquals(0, self.datasource.set.call_count)
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(json.loads(self.ahost), json.loads(body[0]))
+
+        # Make sure creation fails if the request parameters conflict
+        # with an existing host.
+        self.datasource.get.side_effect = None
+        self.datasource.get.reset_mock()
+        self.datasource.set.reset_mock()
+        bad_data = '{"ssh_priv_key": "boguskey"}'
+        body = self.simulate_request(
+            '/api/v0/host', method='PUT', body=bad_data)
+        # datasource's set should not have been called once
+        self.assertEquals(0, self.datasource.set.call_count)
+        self.assertEqual(self.srmock.status, falcon.HTTP_409)
+        self.assertEqual({}, json.loads(body[0]))


### PR DESCRIPTION
This was an idea I had to help with the host auto-join feature.

Programmatically determining a host's own IP address to send to the Commissaire server can be non-trivial given the possibility of multiple network devices.  And even if you know the right device name, parsing it out from `ip address` or `ifconfig` is still a pain.

This helps alleviate the problem by offering a convenient endpoint for hosts to add themselves directly to a cluster.

***Update:*** *After further discussion the endpoint was changed to `/api/v0/host`.*

**Endpoint:** `/api/v0/cluster/{NAME}/join`

Accepts a `PUT` request from the host wishing to join cluster `{NAME}`.
    
This is equivalent to:
```    
   PUT /api/v0/host/{ADDRESS}
    
   {
      cluster: {NAME}
      ...
   }
```
except the host's `{ADDRESS}` is derived from the request itself.