### PR TITLE
gendocs: Use "bash strict mode" by default

### DIFF
--- a/doc/gendocs.sh
+++ b/doc/gendocs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xeuo pipefail
 rm -rf _build
 rm -rf apidoc
 sphinx-apidoc -T -M -e -o apidoc ../src/commissaire/


### PR DESCRIPTION
I was just browsing the code again, and since I've already contributed
to about 7 git repositories today, I figure why not make it 8!