### PR TITLE
Move to CherryPy

### DIFF
--- a/conf/logger.json
+++ b/conf/logger.json
@@ -3,6 +3,9 @@
     "formatters": {
         "simple": {
             "format": "%(asctime)s - %(name)s - %(process)d -  %(thread)d - %(levelname)s - %(message)s"
+        },
+        "void": {
+            "format": ""
         }
     },
     "handlers": {
@@ -11,16 +14,22 @@
             "formatter": "simple",
             "level": "DEBUG",
             "stream": "ext://sys.stdout"
+        },
+        "cherrypy": {
+            "class": "logging.StreamHandler",
+            "formatter": "void",
+            "level": "DEBUG",
+            "stream": "ext://sys.stdout"
         }
     },
     "loggers": {
-        "http-access": {
-            "handlers": ["console"],
+        "cherrypy.access": {
+            "handlers": ["cherrypy"],
             "level": "INFO",
             "propagate": false
         },
-        "http-error": {
-            "handlers": ["console"],
+        "cherrypy.error": {
+            "handlers": ["cherrypy"],
             "level": "INFO",
             "propagate": false
         },

--- a/contrib/package/rpm/commissaire.spec
+++ b/contrib/package/rpm/commissaire.spec
@@ -1,6 +1,6 @@
 Name:           commissaire
 Version:        0.0.1rc2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Simple cluster host management
 License:        AGPLv3+
 URL:            http://github.com/projectatomic/commissaire
@@ -23,13 +23,13 @@ BuildRequires:  pkgconfig(systemd)
 # XXX: Waiting on python2-python-etcd to pass review
 #      https://bugzilla.redhat.com/show_bug.cgi?id=1310796
 Requires:  python-setuptools
+Requires:  python-cherrypy
 Requires:  python2-falcon
 Requires:  python2-python-etcd
-Requires:  python-gevent
 Requires:  python-jinja2
 Requires:  python-requests
 Requires:  py-bcrypt
-Requires:  ansible
+Requires:  ansible >= 2.0.1.0
 
 %description
 Commissaire allows administrators of a Kubernetes, Atomic Enterprise or
@@ -87,6 +87,9 @@ install -D contrib/systemd/commissaire.service %{buildroot}%{_unitdir}/commissai
 
 
 %changelog
+* Thu Mar 17 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-3
+- Now using cherrypy rather than gevent.
+
 * Tue Mar  8 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-2
 - Adding in service items.
 

--- a/doc/apidoc/commissaire.cherrypy_plugins.rst
+++ b/doc/apidoc/commissaire.cherrypy_plugins.rst
@@ -1,0 +1,7 @@
+commissaire.cherrypy_plugins module
+===================================
+
+.. automodule:: commissaire.cherrypy_plugins
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.rst
+++ b/doc/apidoc/commissaire.rst
@@ -24,6 +24,7 @@ Submodules
 
 .. toctree::
 
+   commissaire.cherrypy_plugins
    commissaire.client_script
    commissaire.config
    commissaire.hash_pass_script

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -27,7 +27,7 @@ As you can see commissaire uses a number of libraries.
 
 Of these, the most important to be up to speed on are:
 
-- gevent: http://www.gevent.org/
+- cherrypy: http://www.cherrypy.org/
 - falcon: http://falconframework.org/
 - ansible: https://www.ansible.com/
 

--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -442,14 +442,6 @@ Retrieve a the status of the system.
                "errors": [string,...],  // Errors from the pool
            },
        },
-       "clusterexecpool": {
-           "status": enum(string),      // Status of the clusterexec pool
-           "info": {
-               "size": int,             // Total size of the clusterexec pool
-               "in_use": int,           // Amount of the pool in use
-               "errors": [string,...],  // Errors from the pool
-           }
-       },
    }
 
 .. note::
@@ -473,14 +465,5 @@ Example
                "errors": []
            }
        }
-       "clusterexec": {
-           "status": "OK",
-           "info": {
-               "size": 5,
-               "in_use": 0,
-               "errors": []
-           }
-       }
-
    }
 

--- a/features/steps/status.py
+++ b/features/steps/status.py
@@ -13,5 +13,5 @@ def impl(context):
 def impl(context):
     results = context.request.json()
     print(results.keys())
-    for key in ('investigator', 'etcd', 'clusterexecpool'):
+    for key in ('investigator', 'etcd'):
         assert key in results.keys()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests
 py-bcrypt
 python-etcd==0.4.2
 setuptools
-ansible>=2.0.0.2
+ansible>=2.0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gevent==1.1rc3
+cherrypy==3.2.2
 falcon>=0.3
 requests
 py-bcrypt

--- a/src/commissaire/cherrypy_plugins.py
+++ b/src/commissaire/cherrypy_plugins.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+CherryPy plugin for storing objects.
+"""
+
+import sys
+
+import etcd
+
+from cherrypy.process import plugins
+
+
+class CherryPyStorePlugin(plugins.SimplePlugin):
+
+    def __init__(self, bus, store_kwargs):
+        """
+        Creates a new instance of the CherryPyStorePlugin.
+
+        :param bus: The CherryPy bus.
+        :type bus: cherrypy.process.wspbus.Bus
+        :param store_kwargs: Keyword arguments used to make the Client.
+        :type store_kwargs: dict
+        """
+        plugins.SimplePlugin.__init__(self, bus)
+        self.store_kwargs = store_kwargs
+        self.store = None
+
+    def _get_store(self):
+        """
+        Returns an instance of the store. If one has not been created this call
+        will also create the client using the self.store_kwargs.
+
+        :returns: The store.
+        :rtype: etcd.Client
+        """
+        if not self.store:
+            self.store = etcd.Client(**self.store_kwargs)
+        return self.store
+
+    def start(self):
+        """
+        Starts the plugin.
+        """
+        self.bus.log('Starting up Store access')
+        self.bus.subscribe("store-save", self.store_save)
+        self.bus.subscribe("store-get", self.store_get)
+
+    def stop(self):
+        """
+        Stops the plugin.
+        """
+        self.bus.log('Stopping down Store access')
+        self.bus.unsubscribe("store-save", self.store_save)
+        self.bus.unsubscribe("store-get", self.store_get)
+
+    def store_save(self, key, json_entity):
+        """
+        Saves json to the store.
+
+        :param key: The key to associate the data with.
+        :type key: str
+        :param json_entity: The json data to save.
+        :type json_entity: str
+        :returns: The stores response and any errors that may have occured
+        :rtype: tuple(etcd.EtcdResult, Exception)
+        """
+        try:
+            store = self._get_store()
+            return (store.set(key, json_entity), None)
+        except:
+            _, exc, _ = sys.exc_info()
+            return ([], exc)
+
+    def store_get(self, key):
+        """
+        Retrieves json from the store.
+
+        :param key: The key to associate the data with.
+        :type key: str
+        :returns: The stores response and any errors that may have occured
+        :rtype: tuple(etcd.EtcdResult, Exception)
+        """
+        try:
+            store = self._get_store()
+            return (store.get(key), None)
+        except:
+            _, exc, _ = sys.exc_info()
+            return ([], exc)

--- a/src/commissaire/cherrypy_plugins.py
+++ b/src/commissaire/cherrypy_plugins.py
@@ -66,7 +66,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         self.bus.unsubscribe("store-save", self.store_save)
         self.bus.unsubscribe("store-get", self.store_get)
 
-    def store_save(self, key, json_entity):
+    def store_save(self, key, json_entity, **kwargs):
         """
         Saves json to the store.
 
@@ -74,12 +74,14 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         :type key: str
         :param json_entity: The json data to save.
         :type json_entity: str
+        :param kwargs: All other keyword-args to pass to client
+        :type kwargs: dict
         :returns: The stores response and any errors that may have occured
         :rtype: tuple(etcd.EtcdResult, Exception)
         """
         try:
             store = self._get_store()
-            return (store.set(key, json_entity), None)
+            return (store.write(key, json_entity, **kwargs), None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -17,11 +17,10 @@ Cluster(s) handlers.
 """
 
 import datetime
-import falcon
-import etcd
 import json
 
-# import cherrypy
+import cherrypy
+import falcon
 
 from multiprocessing import Process
 
@@ -47,14 +46,15 @@ class ClustersResource(Resource):
         :param resp: Response instance that will be passed through.
         :type resp: falcon.Response
         """
-        try:
-            clusters_dir = self.store.get('/commissaire/clusters/')
-        except etcd.EtcdKeyNotFound:
+        clusters_dir, error = cherrypy.engine.publish(
+            'store-get', '/commissaire/clusters/')[0]
+        if error:
             self.logger.warn(
                 'Etcd does not have any clusters. Returning [] and 404.')
             resp.status = falcon.HTTP_404
             req.context['model'] = None
             return
+
         results = []
         # Don't let an empty clusters directory through
         if len(clusters_dir._children):
@@ -81,13 +81,14 @@ class ClusterResource(Resource):
         :param cluster: The name of the cluster.
         :type cluster: str
         """
-        try:
-            # XXX: Not sure which wil be more efficient: fetch all
-            #      the host data in one etcd call and sort through
-            #      them, or fetch the ones we need individually.
-            #      For the MVP phase, fetch all is better.
-            etcd_resp = self.store.get('/commissaire/hosts')
-        except etcd.EtcdKeyNotFound:
+        # XXX: Not sure which wil be more efficient: fetch all
+        #      the host data in one etcd call and sort through
+        #      them, or fetch the ones we need individually.
+        #      For the MVP phase, fetch all is better.
+        etcd_resp, error = cherrypy.engine.publish(
+            'store-get', '/commissaire/hosts')[0]
+
+        if error:
             self.logger.warn(
                 'Etcd does not have any hosts. '
                 'Cannot determine cluster stats.')
@@ -118,7 +119,15 @@ class ClusterResource(Resource):
         :param name: The name of the Cluster being requested.
         :type name: str
         """
-        cluster = util.get_cluster_model(self.store, name)
+        key = util.etcd_cluster_key(name)
+        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+
+        if error:
+            resp.status = falcon.HTTP_404
+            return
+
+        cluster = Cluster(**json.loads(etcd_resp.value))
+
         if not cluster:
             resp.status = falcon.HTTP_404
             return
@@ -142,16 +151,15 @@ class ClusterResource(Resource):
         # PUT is idempotent, and since there's no body to this request,
         # there's nothing to conflict with.  The request should always
         # succeed, even if we didn't actually do anything.
-        if util.etcd_cluster_exists(self.store, name):
+        if util.etcd_cluster_exists(name):
             self.logger.info(
                 'Creation of already exisiting cluster {0} requested.'.format(
                     name))
         else:
             key = util.etcd_cluster_key(name)
             cluster = Cluster(status='ok', hostset=[])
-            etcd_resp = self.store.set(key, cluster.to_json(secure=True))
-            # etcd_resp, _ = cherrypy.engine.publish(
-            #    'store-save', key, cluster.to_json(secure=True))[0]
+            etcd_resp, _ = cherrypy.engine.publish(
+                'store-save', key, cluster.to_json(secure=True))[0]
             self.logger.info(
                 'Created cluster {0} per request.'.format(name))
             self.logger.debug('Etcd Response: {0}'.format(etcd_resp))
@@ -169,7 +177,7 @@ class ClusterResource(Resource):
         :type name: str
         """
         resp.body = '{}'
-        if not util.etcd_cluster_exists(self.store, name):
+        if not util.etcd_cluster_exists(name):
             self.logger.info(
                 'Deleting for non-existent cluster {0} requested.'.format(
                     name))
@@ -197,7 +205,7 @@ class ClusterHostsResource(Resource):
         :param name: The name of the Cluster being requested.
         :type name: str
         """
-        cluster = util.get_cluster_model(self.store, name)
+        cluster = util.get_cluster_model(name)
         if not cluster:
             resp.status = falcon.HTTP_404
             return
@@ -228,7 +236,7 @@ class ClusterHostsResource(Resource):
             resp.status = falcon.HTTP_400
             return
 
-        cluster = util.get_cluster_model(self.store, name)
+        cluster = util.get_cluster_model(name)
         if not cluster:
             resp.status = falcon.HTTP_404
             return
@@ -252,7 +260,8 @@ class ClusterHostsResource(Resource):
         #        with the etcd 'modifiedIndex'.  Deferring for now.
 
         cluster.hostset = list(new_hosts)
-        self.store.set(cluster.etcd.key, cluster.to_json(secure=True))
+        cherrypy.engine.publish(
+            'store-save', cluster.etcd.key, cluster.to_json(secure=True))
         resp.status = falcon.HTTP_200
 
 
@@ -276,7 +285,7 @@ class ClusterSingleHostResource(ClusterHostsResource):
         :param address: The address of the Host being requested.
         :type address: str
         """
-        cluster = util.get_cluster_model(self.store, name)
+        cluster = util.get_cluster_model(name)
         if not cluster:
             resp.status = falcon.HTTP_404
             return
@@ -301,7 +310,7 @@ class ClusterSingleHostResource(ClusterHostsResource):
         :type address: str
         """
         try:
-            util.etcd_cluster_add_host(self.store, name, address)
+            util.etcd_cluster_add_host(name, address)
             resp.status = falcon.HTTP_200
         except KeyError:
             resp.status = falcon.HTTP_404
@@ -321,7 +330,7 @@ class ClusterSingleHostResource(ClusterHostsResource):
         :type address: str
         """
         try:
-            util.etcd_cluster_remove_host(self.store, name, address)
+            util.etcd_cluster_remove_host(name, address)
             resp.status = falcon.HTTP_200
         except KeyError:
             resp.status = falcon.HTTP_404
@@ -344,16 +353,15 @@ class ClusterRestartResource(Resource):
         :type name: str
         """
         key = '/commissaire/cluster/{0}/restart'.format(name)
-        try:
-            if not util.etcd_cluster_exists(self.store, name):
-                self.logger.info(
-                    'Restart GET requested for nonexistent cluster {0}'.format(
-                        name))
-                resp.status = falcon.HTTP_404
-                return
-            status = self.store.get(key)
-            self.logger.debug('Etcd Response: {0}'.format(status))
-        except etcd.EtcdKeyNotFound:
+        if not util.etcd_cluster_exists(name):
+            self.logger.info(
+                'Restart GET requested for nonexistent cluster {0}'.format(
+                    name))
+            resp.status = falcon.HTTP_404
+            return
+        status, error = cherrypy.engine.publish('store-get', key)[0]
+        self.logger.debug('Etcd Response: {0}'.format(status))
+        if error:
             # Return "204 No Content" if we have no status,
             # meaning no restart is in progress.  The client
             # can't be expected to know that, so it's not a
@@ -378,7 +386,7 @@ class ClusterRestartResource(Resource):
         :type name: str
         """
         # Make sure the cluster name is valid.
-        if not util.etcd_cluster_exists(self.store, name):
+        if not util.etcd_cluster_exists(name):
             self.logger.info(
                 'Restart PUT requested for nonexistent cluster {0}'.format(
                     name))
@@ -388,8 +396,8 @@ class ClusterRestartResource(Resource):
         # If the operation is already in progress, return the current
         # status with response code 200 OK.
         key = '/commissaire/cluster/{0}/restart'.format(name)
-        try:
-            etcd_resp = self.store.get(key)
+        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+        if not error:
             self.logger.debug('Etcd Response: {0}'.format(etcd_resp))
             cluster_restart = ClusterRestart(**json.loads(etcd_resp.value))
             if not cluster_restart.finished_at:
@@ -398,8 +406,6 @@ class ClusterRestartResource(Resource):
                 resp.status = falcon.HTTP_200
                 req.context['model'] = cluster_restart
                 return
-        except etcd.EtcdKeyNotFound:
-            pass
 
         # TODO: Move to a poll?
         p = Process(target=clusterexec, args=(name, 'restart'))
@@ -415,7 +421,7 @@ class ClusterRestartResource(Resource):
             'finished_at': None
         }
         cluster_restart = ClusterRestart(**cluster_restart_default)
-        self.store.set(key, cluster_restart.to_json())
+        cherrypy.engine.publish('store-set', cluster_restart.to_json())
         resp.status = falcon.HTTP_201
         req.context['model'] = cluster_restart
 
@@ -437,16 +443,17 @@ class ClusterUpgradeResource(Resource):
         :type name: str
         """
         key = '/commissaire/cluster/{0}/upgrade'.format(name)
-        try:
-            if not util.etcd_cluster_exists(self.store, name):
-                self.logger.info(
-                    'Upgrade GET requested for nonexistent cluster {0}'.format(
-                        name))
-                resp.status = falcon.HTTP_404
-                return
-            status = self.store.get(key)
-            self.logger.debug('Etcd Response: {0}'.format(status))
-        except etcd.EtcdKeyNotFound:
+        if not util.etcd_cluster_exists(name):
+            self.logger.info(
+                'Upgrade GET requested for nonexistent cluster {0}'.format(
+                    name))
+            resp.status = falcon.HTTP_404
+            return
+
+        status, error = cherrypy.engine.publish('store-get', key)[0]
+        self.logger.debug('Etcd Response: {0}'.format(status))
+
+        if error:
             # Return "204 No Content" if we have no status,
             # meaning no upgrade is in progress.  The client
             # can't be expected to know that, so it's not a
@@ -480,7 +487,7 @@ class ClusterUpgradeResource(Resource):
             return
 
         # Make sure the cluster name is valid.
-        if not util.etcd_cluster_exists(self.store, name):
+        if not util.etcd_cluster_exists(name):
             self.logger.info(
                 'Upgrade PUT requested for nonexistent cluster {0}'.format(
                     name))
@@ -492,9 +499,9 @@ class ClusterUpgradeResource(Resource):
         # If the requested version conflicts with the operation in progress,
         # return the current status with response code 409 Conflict.
         key = '/commissaire/cluster/{0}/upgrade'.format(name)
-        try:
-            etcd_resp = self.store.get(key)
-            self.logger.debug('Etcd Response: {0}'.format(etcd_resp))
+        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+        self.logger.debug('Etcd Response: {0}'.format(etcd_resp))
+        if not error:
             cluster_upgrade = ClusterUpgrade(**json.loads(etcd_resp.value))
             if not cluster_upgrade.finished_at:
                 if cluster_upgrade.upgrade_to == upgrade_to:
@@ -510,8 +517,6 @@ class ClusterUpgradeResource(Resource):
                     resp.status = falcon.HTTP_409
                 req.context['model'] = cluster_upgrade
                 return
-        except etcd.EtcdKeyNotFound:
-            pass
 
         # FIXME: How do I pass 'upgrade_to'?
         p = Process(target=clusterexec, args=(name, 'upgrade'))
@@ -527,6 +532,7 @@ class ClusterUpgradeResource(Resource):
             'finished_at': None
         }
         cluster_upgrade = ClusterUpgrade(**cluster_upgrade_default)
-        self.store.set(key, cluster_upgrade.to_json())
+        cherrypy.engine.publish(
+            'store-save', key, cluster_upgrade.to_json())[0]
         resp.status = falcon.HTTP_201
         req.context['model'] = cluster_upgrade

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -101,4 +101,4 @@ class Status(Model):
     """
     _json_type = dict
     _attributes = (
-        'etcd', 'investigator', 'clusterexecpool')
+        'etcd', 'investigator')

--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -16,8 +16,8 @@
 Status handlers.
 """
 
+import cherrypy
 import falcon
-import etcd
 
 from commissaire.jobs import PROCS
 from commissaire.resource import Resource
@@ -55,10 +55,10 @@ class StatusResource(Resource):
         resp.status = falcon.HTTP_503
 
         # Check etcd connection
-        try:
-            self.store.get('/')
+        root_dir, error = cherrypy.engine.publish('store-get', '/')[0]
+        if not error:
             kwargs['etcd']['status'] = 'OK'
-        except etcd.EtcdKeyNotFound:
+        else:
             self.logger.debug('There is no root directory in etcd...')
             kwargs['etcd']['status'] = 'FAILED'
 

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -15,6 +15,7 @@
 """
 Resource utilities.
 """
+# import cherrypy
 
 import etcd
 import falcon
@@ -159,10 +160,15 @@ def get_cluster_model(store, name):
     :type name: str
     """
     key = etcd_cluster_key(name)
+    # etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+    # if error:
+    #     return None
+
     try:
         etcd_resp = store.get(key)
     except etcd.EtcdKeyNotFound:
         return None
+
     cluster = Cluster(**json.loads(etcd_resp.value))
     cluster.etcd = etcd_resp
     return cluster

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -15,9 +15,7 @@
 """
 Resource utilities.
 """
-# import cherrypy
-
-import etcd
+import cherrypy
 import falcon
 import json
 
@@ -45,43 +43,39 @@ def etcd_cluster_key(name):
     return '/commissaire/clusters/{0}'.format(name)
 
 
-def etcd_cluster_exists(store, name):
+def etcd_cluster_exists(name):
     """
     Returns whether a cluster with the given name exists.
 
-    :param store: Data store.
-    :type store: etcd.Client
     :param name: Name of a cluster
     :type name: str
     """
     key = etcd_cluster_key(name)
-    try:
-        store.get(key)
+
+    etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+    if not error:
         return True
-    except etcd.EtcdKeyNotFound:
-        return False
+    return False
 
 
-def etcd_cluster_has_host(store, name, address):
+def etcd_cluster_has_host(name, address):
     """
     Checks if a host address belongs to a cluster with the given name.
     If no such cluster exists, the function raises KeyError.
 
-    :param store: Data store.
-    :type store: etcd.Client
     :param name: Name of a cluster
     :type name: str
     :param address: Host address
     :type address: str
     """
-    cluster = get_cluster_model(store, name)
+    cluster = get_cluster_model(name)
     if not cluster:
         raise KeyError
 
     return address in cluster.hostset
 
 
-def etcd_cluster_add_host(store, name, address):
+def etcd_cluster_add_host(name, address):
     """
     Adds a host address to a cluster with the given name.
     If no such cluster exists, the function raises KeyError.
@@ -89,14 +83,12 @@ def etcd_cluster_add_host(store, name, address):
     Note the function is idempotent: if the host address is
     already in the cluster, no change occurs.
 
-    :param store: Data store.
-    :type store: etcd.Client
     :param name: Name of a cluster
     :type name: str
     :param address: Host address to add
     :type address: str
     """
-    cluster = get_cluster_model(store, name)
+    cluster = get_cluster_model(name)
     if not cluster:
         raise KeyError
 
@@ -111,13 +103,15 @@ def etcd_cluster_add_host(store, name, address):
 
     if address not in cluster.hostset:
         cluster.hostset.append(address)
-        r = store.write(
-            cluster.etcd.key,
-            cluster.to_json(secure=True),
-            prevValue=cluster.etcd.value)
+
+    etcd_resp, _ = cherrypy.engine.publish(
+        'store-save',
+        cluster.etcd.key,
+        cluster.to_json(secure=True),
+        prevValue=cluster.etcd.value)[0]
 
 
-def etcd_cluster_remove_host(store, name, address):
+def etcd_cluster_remove_host(name, address):
     """
     Removes a host address from a cluster with the given name.
     If no such cluster exists, the function raises KeyError.
@@ -125,14 +119,13 @@ def etcd_cluster_remove_host(store, name, address):
     Note the function is idempotent: if the host address is
     not in the cluster, no change occurs.
 
-    :param store: Data store.
-    :type store: etcd.Client
+
     :param name: Name of a cluster
     :type name: str
     :param address: Host address to remove
     :type address: str
     """
-    cluster = get_cluster_model(store, name)
+    cluster = get_cluster_model(name)
     if not cluster:
         raise KeyError
 
@@ -143,10 +136,13 @@ def etcd_cluster_remove_host(store, name, address):
 
     if address in cluster.hostset:
         cluster.hostset.remove(address)
-        store.set(cluster.etcd.key, cluster.to_json(secure=True))
+        cherrypy.engine.publish(
+            'store-save',
+            cluster.etcd.key,
+            cluster.to_json(secure=True))[0]
 
 
-def get_cluster_model(store, name):
+def get_cluster_model(name):
     """
     Returns a Cluster instance from the etcd record for the given
     cluster name, if it exists, or else None.
@@ -154,19 +150,13 @@ def get_cluster_model(store, name):
     For convenience, the EtcdResult is embedded in the Cluster instance
     as an 'etcd' property.
 
-    :param store: Data store.
-    :type store: etcd.Client
     :param name: Name of a cluster
     :type name: str
     """
     key = etcd_cluster_key(name)
-    # etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
-    # if error:
-    #     return None
+    etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
 
-    try:
-        etcd_resp = store.get(key)
-    except etcd.EtcdKeyNotFound:
+    if error:
         return None
 
     cluster = Cluster(**json.loads(etcd_resp.value))
@@ -174,7 +164,7 @@ def get_cluster_model(store, name):
     return cluster
 
 
-def etcd_host_create(store, address, ssh_priv_key, cluster_name=None):
+def etcd_host_create(address, ssh_priv_key, cluster_name=None):
     """
     Creates a new host record in etcd and optionally adds the host to
     the specified cluster.  Returns a (status, host) tuple where status
@@ -184,8 +174,6 @@ def etcd_host_create(store, address, ssh_priv_key, cluster_name=None):
     This function is idempotent so long as the host parameters agree
     with an existing host record and cluster membership.
 
-    :param store: Data store.
-    :type store: etcd.Client
     :param address: Host address.
     :type address: str
     :param ssh_priv_key: Host's SSH key, base64-encoded.
@@ -196,16 +184,16 @@ def etcd_host_create(store, address, ssh_priv_key, cluster_name=None):
     :rtype: tuple
     """
     key = etcd_host_key(address)
-    try:
-        etcd_resp = store.get(key)
+    etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
 
+    if not error:
         # Check if the request conflicts with the existing host.
         existing_host = Host(**json.loads(etcd_resp.value))
         if existing_host.ssh_priv_key != ssh_priv_key:
             return (falcon.HTTP_409, None)
         if cluster_name:
             try:
-                assert etcd_cluster_has_host(store, cluster_name, address)
+                assert etcd_cluster_has_host(cluster_name, address)
             except (AssertionError, KeyError):
                 return (falcon.HTTP_409, None)
 
@@ -213,8 +201,6 @@ def etcd_host_create(store, address, ssh_priv_key, cluster_name=None):
         # we're done.  (Not using HTTP_201 since we didn't
         # actually create anything.)
         return (falcon.HTTP_200, existing_host)
-    except etcd.EtcdKeyNotFound:
-        pass
 
     host_creation = {
         'address': address,
@@ -230,15 +216,17 @@ def etcd_host_create(store, address, ssh_priv_key, cluster_name=None):
     # Verify the cluster exists, if given.  Do it now
     # so we can fail before writing anything to etcd.
     if cluster_name:
-        if not etcd_cluster_exists(store, cluster_name):
+        if not etcd_cluster_exists(cluster_name):
             return (falcon.HTTP_409, None)
 
     host = Host(**host_creation)
-    new_host = store.set(key, host.to_json(secure=True))
+
+    new_host, _ = cherrypy.engine.publish(
+        'store-save', key, host.to_json(secure=True))[0]
 
     # Add host to the requested cluster.
     if cluster_name:
-        etcd_cluster_add_host(store, cluster_name, address)
+        etcd_cluster_add_host(cluster_name, address)
 
     INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
 

--- a/src/commissaire/jobs/__init__.py
+++ b/src/commissaire/jobs/__init__.py
@@ -15,13 +15,6 @@
 """
 Storage for greenlets.
 """
-from gevent.pool import Pool
-
-
-#: All green pools
-POOLS = {
-    'clusterexecpool': Pool(5),
-}
 
 #: All multiprocessing processes
 PROCS = {

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -69,9 +69,15 @@ def clusterexec(cluster_name, command):
         json.dumps(cluster_status))[0]
 
     # Collect all host addresses in the cluster
-    etcd_resp, _ = cherrypy.engine.publish(
+    etcd_resp, error = cherrypy.engine.publish(
         'store-get', '/commissaire/clusters/{0}'.format(cluster_name))[0]
-    print etcd_resp.value
+
+    if error:
+        logger.warn(
+            'Unable to continue for {0} due to '
+            '{1}: {2}. Returning...'.format(cluster_name, type(error), error))
+        return
+
     cluster_hosts = set(json.loads(etcd_resp.value).get('hostset', []))
     if cluster_hosts:
         logger.debug(

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -16,6 +16,7 @@
 The investigator job.
 """
 
+import cherrypy
 import datetime
 import etcd
 import json
@@ -50,7 +51,7 @@ def clean_up_key(key_file):
             '{0}. Exception:{1}'.format(key_file, exc_msg))
 
 
-def investigator(queue, config, store_kwargs, run_once=False):
+def investigator(queue, config, run_once=False):
     """
     Investigates new hosts to retrieve and store facts.
 
@@ -58,14 +59,9 @@ def investigator(queue, config, store_kwargs, run_once=False):
     :type queue: Queue.Queue
     :param config: Configuration information.
     :type config: commissaire.config.Config
-    :param store_kwargs: Keyword arguments to use when creating an etcd.Client
-    :type store_kwargs: dict
     """
     logger = logging.getLogger('investigator')
     logger.info('Investigator started')
-
-    # Create our own client for use in this process
-    store = etcd.Client(**store_kwargs)
 
     while True:
         # Statuses follow:
@@ -87,7 +83,8 @@ def investigator(queue, config, store_kwargs, run_once=False):
         f.close()
 
         key = '/commissaire/hosts/{0}'.format(address)
-        data = json.loads(store.get(key).value)
+        etcd_resp, _ = cherrypy.engine.publish('store-get', key)[0]
+        data = json.loads(etcd_resp.value)
 
         try:
             result, facts = transport.get_info(address, key_file)
@@ -101,13 +98,13 @@ def investigator(queue, config, store_kwargs, run_once=False):
             logger.warn('Getting info failed for {0}: {1}'.format(
                 address, exc_msg))
             data['status'] = 'failed'
-            store.set(key, json.dumps(data))
+            cherrypy.engine.publish('store-save', key, json.dumps(data))[0]
             clean_up_key(key_file)
             if run_once:
                 break
             continue
 
-        store.set(key, json.dumps(data))
+        cherrypy.engine.publish('store-save', key, json.dumps(data))[0]
         logger.info(
             'Finished and stored investigation data for {0}'.format(address))
         logger.debug('Finished investigation update for {0}: {1}'.format(
@@ -119,13 +116,13 @@ def investigator(queue, config, store_kwargs, run_once=False):
             result, facts = transport.bootstrap(
                 address, key_file, config, oscmd)
             data['status'] = 'inactive'
-            store.set(key, json.dumps(data))
+            cherrypy.engine.publish('store-save', key, json.dumps(data))[0]
         except:
             exc_type, exc_msg, tb = sys.exc_info()
             logger.warn('Unable to start bootstraping for {0}: {1}'.format(
                 address, exc_msg))
             data['status'] = 'disassociated'
-            store.set(key, json.dumps(data))
+            cherrypy.engine.publish('store-save', key, json.dumps(data))[0]
             clean_up_key(key_file)
             if run_once:
                 break
@@ -156,7 +153,7 @@ def investigator(queue, config, store_kwargs, run_once=False):
                 'the container manager: {1}'.format(address, exc_msg))
             data['status'] = 'inactive'
 
-        store.set(key, json.dumps(data))
+        cherrypy.engine.publish('store-save', key, json.dumps(data))[0]
         logger.info(
             'Finished bootstrapping for {0}'.format(address))
         logging.debug('Finished bootstrapping for {0}: {1}'.format(

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -18,7 +18,6 @@ The investigator job.
 
 import cherrypy
 import datetime
-import etcd
 import json
 import logging
 import os

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -24,7 +24,7 @@ import os
 import sys
 import tempfile
 
-from gevent import sleep
+from time import sleep
 
 from commissaire.compat.b64 import base64
 from commissaire.containermgr.kubernetes import KubeContainerManager
@@ -55,7 +55,7 @@ def investigator(queue, config, store_kwargs, run_once=False):
     Investigates new hosts to retrieve and store facts.
 
     :param queue: Queue to pull work from.
-    :type queue: gevent.queue.Queue
+    :type queue: Queue.Queue
     :param config: Configuration information.
     :type config: commissaire.config.Config
     :param store_kwargs: Keyword arguments to use when creating an etcd.Client
@@ -67,10 +67,10 @@ def investigator(queue, config, store_kwargs, run_once=False):
     # Create our own client for use in this process
     store = etcd.Client(**store_kwargs)
 
-    transport = ansibleapi.Transport()
     while True:
         # Statuses follow:
         # http://commissaire.readthedocs.org/en/latest/enums.html#host-statuses
+        transport = ansibleapi.Transport()
         to_investigate, ssh_priv_key = queue.get()
         address = to_investigate['address']
         logger.info('{0} is now in investigating.'.format(address))

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -83,7 +83,14 @@ def investigator(queue, config, run_once=False):
         f.close()
 
         key = '/commissaire/hosts/{0}'.format(address)
-        etcd_resp, _ = cherrypy.engine.publish('store-get', key)[0]
+        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+        if error:
+            logger.warn(
+                'Unable to continue for {0} due to '
+                '{1}: {2}. Returning...'.format(address, type(error), error))
+            clean_up_key(key_file)
+            continue
+
         data = json.loads(etcd_resp.value)
 
         try:

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -15,11 +15,7 @@
 """
 """
 
-from gevent.monkey import patch_all
-patch_all(thread=False)
-
-import datetime
-import base64
+import cherrypy
 import json
 import logging
 import logging.config
@@ -27,9 +23,6 @@ import os
 
 import etcd
 import falcon
-import gevent
-
-from gevent.pywsgi import WSGIServer, LoggingLogAdapter, socket
 
 from commissaire.compat.urlparser import urlparse
 from commissaire.compat import exception
@@ -42,7 +35,7 @@ from commissaire.handlers.hosts import (
     HostsResource, HostResource, ImplicitHostResource)
 from commissaire.handlers.status import StatusResource
 from commissaire.queues import INVESTIGATE_QUEUE
-from commissaire.jobs import POOLS, PROCS
+from commissaire.jobs import PROCS
 from commissaire.jobs.investigator import investigator
 from commissaire.authentication import httpauth
 from commissaire.middleware import JSONify
@@ -125,7 +118,7 @@ def main():  # pragma: no cover
     import argparse
 
     from multiprocessing import Process
-
+    from commissaire.cherrypy_plugins import CherryPyStorePlugin
     config = Config()
 
     epilog = ('Example: ./commissaire -e http://127.0.0.1:2379'
@@ -212,27 +205,14 @@ def main():  # pragma: no cover
         raise SystemExit(1)
 
     # TLS options
-    ssl_args = {}
     tls_keyfile = cli_etcd_or_default(
         'tlskeyfile', args.tls_keyfile, None, ds)
     tls_certfile = cli_etcd_or_default(
         'tlscertfile', args.tls_certfile, None, ds)
-    if tls_keyfile is not None and tls_certfile is not None:
-        ssl_args = {
-            'keyfile': tls_keyfile,
-            'certfile': tls_certfile,
-        }
-        logging.info('Commissaire server TLS will be enabled.')
-    elif tls_keyfile is not None or tls_certfile is not None:
-        parser.error(
-            'Both a keyfile and certfile must be '
-            'given for commissaire server TLS. Exiting ...')
 
     interface = cli_etcd_or_default(
         'listeninterface', args.listen_interface, '0.0.0.0', ds)
     port = cli_etcd_or_default('listenport', args.listen_port, 8000, ds)
-    config.etcd['listen'] = urlparse('http://{0}:{1}'.format(
-        interface, port))
 
     # Pull options for accessing kubernetes
     try:
@@ -254,32 +234,46 @@ def main():  # pragma: no cover
     PROCS['investigator'] = Process(
         target=investigator, args=(INVESTIGATE_QUEUE, config, store_kwargs))
     PROCS['investigator'].start()
+
+    # Add our config instance to the cherrypy global config so we can use it's
+    # values elsewhere
+    # TODO: Technically this should be in the cherrypy.request.app.config
+    # but it looks like that isn't accessable with WSGI based apps
+    cherrypy.config['commissaire.config'] = config
+
     logging.debug('Config: {0}'.format(config))
 
     app = create_app(ds)
-    try:
-        access_logger = logging.getLogger('http-access')
-        error_logger = logging.getLogger('http-error')
-        kwargs = {
-            'listener': (interface, int(port)),
-            'application': app,
-            'log': LoggingLogAdapter(access_logger, access_logger.level),
-            'error_log': LoggingLogAdapter(error_logger, error_logger.level),
-        }
-        kwargs.update(ssl_args)
-        logging.debug('WSGIServer args: {0}'.format(kwargs))
 
-        server = WSGIServer(**kwargs)
+    cherrypy.server.unsubscribe()
+    # Disable autoreloading and use our logger
+    cherrypy.config.update({'log.screen': False,
+                            'log.access_file': '',
+                            'log.error_file': '',
+                            'engine.autoreload.on': False})
+    cherrypy.tree.graft(app, "/")
+    server = cherrypy._cpserver.Server()
+    server.socket_host = interface
+    server.socket_port = int(port)
+    server.thread_pool = 10
 
-        # Catch SIGTERM and stop the server.
-        gevent.signal.signal(
-            gevent.signal._signal.SIGTERM, lambda s, f: server.stop())
-        server.serve_forever()
-    except socket.error:
-        _, ex, _ = exception.raise_if_not(socket.error)
-        logging.fatal(ex)
-    except KeyboardInterrupt:
-        pass
+    if bool(tls_keyfile) ^ bool(tls_certfile):
+        parser.error(
+            'Both a keyfile and certfile must be '
+            'given for commissaire server TLS. Exiting ...')
+    if tls_keyfile and tls_certfile:
+        server.ssl_module = 'builtin'
+        server.ssl_certificate = tls_certfile
+        server.ssl_private_key = tls_keyfile
+        logging.info('Commissaire server TLS will be enabled.')
+
+    server.subscribe()
+
+    # Add our plugins
+    CherryPyStorePlugin(cherrypy.engine, store_kwargs).subscribe()
+
+    cherrypy.engine.start()
+    cherrypy.engine.block()
 
     PROCS['investigator'].terminate()
     PROCS['investigator'].join()

--- a/test/test_cherrypy_plugins.py
+++ b/test/test_cherrypy_plugins.py
@@ -100,10 +100,10 @@ class Test_CherryPyStorePlugin(TestCase):
         with mock.patch('etcd.Client') as _store:
             store = _store()
             expected_result = mock.MagicMock('etcd.EtcdResult')
-            store.set.return_value = expected_result
+            store.write.return_value = expected_result
             result = self.plugin.store_save(key, data)
             # The store should be called to set the data
-            store.set.assert_called_once_with(key, data)
+            store.write.assert_called_once_with(key, data)
             # The result should be a tuple
             self.assertEquals((expected_result, None), result)
 
@@ -116,10 +116,10 @@ class Test_CherryPyStorePlugin(TestCase):
         with mock.patch('etcd.Client') as _store:
             store = _store()
             expected_result = Exception()
-            store.set.side_effect = expected_result
+            store.write.side_effect = expected_result
             result = self.plugin.store_save(key, data)
             # The store should be called to set the data
-            store.set.assert_called_once_with(key, data)
+            store.write.assert_called_once_with(key, data)
             # The result should be a tuple
             self.assertEquals(([], expected_result), result)
 

--- a/test/test_cherrypy_plugins.py
+++ b/test/test_cherrypy_plugins.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire.cherrypy_plugins module.
+"""
+
+import mock
+
+from . import TestCase
+from commissaire import cherrypy_plugins
+
+
+class Test_CherryPyStorePlugin(TestCase):
+    """
+    Tests for the CherryPyStorePlugin class.
+    """
+
+    #: Topics that should be registered
+    topics = ('store-get', 'store-save')
+
+    def before(self):
+        """
+        Called before every test.
+        """
+        self.bus = mock.MagicMock()
+        self.store_kwargs = {}
+        self.plugin = cherrypy_plugins.CherryPyStorePlugin(
+            self.bus, self.store_kwargs)
+
+    def after(self):
+        """
+        Called after every test.
+        """
+        self.bus = None
+        self.plugin = None
+
+    def test_cherrypy_store_plugin_creation(self):
+        """
+        Verify that the creation of the plugin works as it should.
+        """
+        with mock.patch('etcd.Client') as _store:
+            # Store should be None
+            self.assertEquals(None, self.plugin.store)
+            # The Store should not have been called in any way
+            self.assertEquals(0, _store().call_count)
+
+    def test_cherrypy_store_plugin__get_store(self):
+        """
+        Verify _get_store properly obtains a store instance.
+        """
+        with mock.patch('etcd.Client') as _store:
+            store = self.plugin._get_store()
+            # We should have a store created with our kwargs
+            _store.assert_called_once_with(**self.store_kwargs)
+            # The returned stoer should be exactly the same
+            self.assertEquals(store, _store())
+            self.assertEquals(store, self.plugin.store)
+
+    def test_cherrypy_store_plugin_start(self):
+        """
+        Verify start() subscribes the proper topics.
+        """
+        self.plugin.start()
+        # subscribe should be called a specific number of times
+        self.assertEquals(len(self.topics), self.bus.subscribe.call_count)
+        # Each subscription should have it's own call to register a callback
+        for topic in self.topics:
+            self.bus.subscribe.assert_any_call(topic, mock.ANY)
+
+    def test_cherrypy_store_plugin_stop(self):
+        """
+        Verify stop() unsubscribes the proper topics.
+        """
+        self.plugin.stop()
+        # unsubscribe should be called a specific number of times
+        self.assertEquals(len(self.topics), self.bus.unsubscribe.call_count)
+        # Each unsubscription should have it's own call
+        # to deregister a callback
+        for topic in self.topics:
+            self.bus.unsubscribe.assert_any_call(topic, mock.ANY)
+
+    def test_cherrypy_store_save(self):
+        """
+        Verify store_save handles data properly.
+        """
+        key = '/test'
+        data = "{}"
+        with mock.patch('etcd.Client') as _store:
+            store = _store()
+            expected_result = mock.MagicMock('etcd.EtcdResult')
+            store.set.return_value = expected_result
+            result = self.plugin.store_save(key, data)
+            # The store should be called to set the data
+            store.set.assert_called_once_with(key, data)
+            # The result should be a tuple
+            self.assertEquals((expected_result, None), result)
+
+    def test_cherrypy_store_save_error(self):
+        """
+        Verify store_save handles errors properly.
+        """
+        key = '/test'
+        data = "{}"
+        with mock.patch('etcd.Client') as _store:
+            store = _store()
+            expected_result = Exception()
+            store.set.side_effect = expected_result
+            result = self.plugin.store_save(key, data)
+            # The store should be called to set the data
+            store.set.assert_called_once_with(key, data)
+            # The result should be a tuple
+            self.assertEquals(([], expected_result), result)
+
+    def test_cherrypy_store_get(self):
+        """
+        Verify store_get returns data properly.
+        """
+        key = '/test'
+        with mock.patch('etcd.Client') as _store:
+            store = _store()
+            expected_result = mock.MagicMock('etcd.EtcdResult')
+            store.get.return_value = expected_result
+            result = self.plugin.store_get(key)
+            # The store should be called to get the data
+            store.get.assert_called_once_with(key)
+            # The result should be a tuple
+            self.assertEquals((expected_result, None), result)
+
+    def test_cherrypy_store_get_error(self):
+        """
+        Verify store_get returns errors properly.
+        """
+        key = '/test'
+        with mock.patch('etcd.Client') as _store:
+            store = _store()
+            expected_result = Exception()
+            store.get.side_effect = expected_result
+            result = self.plugin.store_get(key)
+            # The store should be called to get the data
+            store.get.assert_called_once_with(key)
+            # The result should be a tuple
+            self.assertEquals(([], expected_result), result)

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -82,43 +82,44 @@ class Test_ClustersResource(TestCase):
         """
         Verify listing Clusters.
         """
-        child = MagicMock(key=self.cluster_name)
-        self.return_value._children = [child]
-        self.return_value.leaves = self.return_value._children
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            child = MagicMock(key=self.cluster_name)
+            return_value = MagicMock(etcd.EtcdResult)
+            return_value._children = [child]
+            return_value.leaves = return_value._children
+            _publish.return_value = [[return_value, None]]
 
-        body = self.simulate_request('/api/v0/clusters')
-        # datasource's get should have been called once
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            body = self.simulate_request('/api/v0/clusters')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
 
-        self.assertEqual(
-            [self.cluster_name],
-            json.loads(body[0]))
+            self.assertEqual(
+                [self.cluster_name],
+                json.loads(body[0]))
 
     def test_clusters_listing_with_no_clusters(self):
         """
         Verify listing Clusters when no clusters exist.
         """
-        self.return_value._children = []
-        self.return_value.leaves = self.return_value._children
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            return_value = MagicMock(etcd.EtcdResult)
+            return_value._children = []
+            return_value.leaves = return_value._children
+            _publish.return_value = [[return_value, None]]
 
-        body = self.simulate_request('/api/v0/clusters')
-        # datasource's get should have been called once
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual({}, json.loads(body[0]))
+            body = self.simulate_request('/api/v0/clusters')
+            self.assertEqual(self.srmock.status, falcon.HTTP_200)
+            self.assertEqual({}, json.loads(body[0]))
 
     def test_clusters_listing_with_no_etcd_result(self):
         """
         Verify listing Clusters handles no etcd result properly.
         """
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
 
-        body = self.simulate_request('/api/v0/clusters')
-        # datasource's get should have been called once
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(self.srmock.status, falcon.HTTP_404)
-        self.assertEqual('{}', body[0])
+            body = self.simulate_request('/api/v0/clusters')
+            self.assertEqual(self.srmock.status, falcon.HTTP_404)
+            self.assertEqual('{}', body[0])
 
 
 class Test_Cluster(TestCase):
@@ -179,77 +180,78 @@ class Test_ClusterResource(TestCase):
         """
         Verify retrieving a cluster.
         """
-        # Verify if the cluster exists the data is returned
-        child = {'value': self.etcd_host}
-        hosts_return_value = MagicMock(
-            etcd.EtcdResult, leaves=[child],
-            value=child, _children=[child])
-        # First call return is etcd_cluster, second is the host_return_value
-        self.datasource.get.side_effect = (
-            MagicMock(value=self.etcd_cluster), hosts_return_value)
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify if the cluster exists the data is returned
+            child = {'value': self.etcd_host}
+            hosts_return_value = MagicMock(
+                etcd.EtcdResult, leaves=[child],
+                value=child, _children=[child])
 
-        body = self.simulate_request('/api/v0/cluster/development')
-        # datasource's get should have been called once
-        self.assertEquals(2, self.datasource.get.call_count)
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(
-            json.loads(self.acluster),
-            json.loads(body[0]))
+            _publish.side_effect = (
+                [[MagicMock(value=self.etcd_cluster), None]],
+                [[hosts_return_value, None]]
+            )
 
-        # Verify no cluster returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
+            body = self.simulate_request('/api/v0/cluster/development')
+            self.assertEqual(self.srmock.status, falcon.HTTP_200)
+            self.assertEqual(
+                json.loads(self.acluster),
+                json.loads(body[0]))
 
-        body = self.simulate_request('/api/v0/cluster/bogus')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify no cluster returns the proper result
+            _publish.reset_mock()
+            _publish.side_effect = None
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+
+            body = self.simulate_request('/api/v0/cluster/bogus')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
     def test_cluster_create(self):
         """
         Verify creating a cluster.
         """
-        # Verify with creation
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        self.datasource.set.return_value = MagicMock(
-            value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development', method='PUT')
-        self.assertEquals(falcon.HTTP_201, self.srmock.status)
-        self.assertEquals('{}', body[0])
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify with creation
+            _publish.side_effect = (
+                [[[], etcd.EtcdKeyNotFound]],
+                [[MagicMock(value=self.etcd_cluster), None]],
+                [[MagicMock(value=self.etcd_cluster), None]],
+            )
 
-        # Verify with existing cluster
-        self.datasource.get.return_value = MagicMock(
-            value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development', method='PUT')
-        self.assertEquals(falcon.HTTP_201, self.srmock.status)
-        self.assertEquals('{}', body[0])
+            body = self.simulate_request(
+                '/api/v0/cluster/development', method='PUT')
+            self.assertEquals(falcon.HTTP_201, self.srmock.status)
+            self.assertEquals('{}', body[0])
+
+            # Verify with existing cluster
+            _publish.return_value = MagicMock(
+                value=self.etcd_cluster)
+            body = self.simulate_request(
+                '/api/v0/cluster/development', method='PUT')
+            self.assertEquals(falcon.HTTP_201, self.srmock.status)
+            self.assertEquals('{}', body[0])
 
     def test_cluster_delete(self):
         """
         Verify deleting a cluster.
         """
-        # Verify with proper deletion
-        body = self.simulate_request(
-            '/api/v0/cluster/development', method='DELETE')
-        # Get is called to verify cluster exists
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(1, self.datasource.delete.call_count)
-        self.assertEquals(falcon.HTTP_410, self.srmock.status)
-        self.assertEquals('{}', body[0])
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify with proper deletion
+            _publish.return_value = [[MagicMock(), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development', method='DELETE')
+            # Get is called to verify cluster exists
+            self.assertEquals(falcon.HTTP_410, self.srmock.status)
+            self.assertEquals('{}', body[0])
 
-        # Verify when key doesn't exist
-        self.datasource.get.reset_mock()
-        self.datasource.delete.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request(
-            '/api/v0/cluster/development', method='DELETE')
-        # Get is called to verify cluster exists
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.delete.call_count)
-        self.assertEquals(falcon.HTTP_404, self.srmock.status)
-        self.assertEquals('{}', body[0])
+            # Verify when key doesn't exist
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development', method='DELETE')
+            # Get is called to verify cluster exists
+            self.assertEquals(falcon.HTTP_404, self.srmock.status)
+            self.assertEquals('{}', body[0])
 
 
 class Test_ClusterRestart(TestCase):
@@ -296,20 +298,20 @@ class Test_ClusterRestartResource(TestCase):
         """
         Verify retrieving a cluster restart.
         """
-        # Verify if the cluster restart exists the data is returned
-        self.datasource.get.return_value = MagicMock(value=self.arestart)
-        body = self.simulate_request('/api/v0/cluster/development/restart')
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEquals(2, self.datasource.get.call_count)
-        self.assertEqual(json.loads(self.arestart), json.loads(body[0]))
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify if the cluster restart exists the data is returned
+            _publish.return_value = [[MagicMock(value=self.arestart), None]]
+            body = self.simulate_request('/api/v0/cluster/development/restart')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual(json.loads(self.arestart), json.loads(body[0]))
 
-        # Verify no cluster restart returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.side_effect = [None, etcd.EtcdKeyNotFound]
-        body = self.simulate_request('/api/v0/cluster/development/restart')
-        self.assertEquals(2, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_204, self.srmock.status)
-        self.assertEqual([], body)  # Empty data'''
+            # Verify no cluster restart returns the proper result
+            _publish.side_effect = (
+                [[MagicMock(value=self.arestart), None]],
+                [[[], etcd.EtcdKeyNotFound()]])
+            body = self.simulate_request('/api/v0/cluster/development/restart')
+            self.assertEqual(falcon.HTTP_204, self.srmock.status)
+            self.assertEqual([], body)  # Empty data
 
     def test_cluster_restart_create(self):
         """
@@ -319,11 +321,20 @@ class Test_ClusterRestartResource(TestCase):
         # Process is patched because we don't want to exec the subprocess
         # during unittesting
         with contextlib.nested(
+                mock.patch('cherrypy.engine.publish'),
                 mock.patch('etcd.Client'),
-                mock.patch('commissaire.handlers.clusters.Process')):
-            self.datasource.get.side_effect = (
-                MagicMock(value=self.etcd_cluster),
-                etcd.EtcdKeyNotFound)
+                mock.patch('commissaire.handlers.clusters.Process')) as (
+                    _publish, _, _):
+
+            # self.datasource.get.side_effect = (
+            #     MagicMock(value=self.etcd_cluster),
+            #     etcd.EtcdKeyNotFound)
+
+            _publish.side_effect = (
+                [[MagicMock(value=self.etcd_cluster), None]],
+                [[[], etcd.EtcdKeyNotFound]],
+                [[MagicMock(etcd.EtcdResult, value=self.arestart), None]])
+
             body = self.simulate_request(
                 '/api/v0/cluster/development/restart',
                 method='PUT')
@@ -358,87 +369,71 @@ class Test_ClusterHostsResource(TestCase):
         """
         Verify retrieving a cluster host list.
         """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify if the cluster exists the host list is returned
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request('/api/v0/cluster/development/hosts')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual(
+                json.loads(self.ahostset),
+                json.loads(body[0]))
 
-        # Verify if the cluster exists the host list is returned
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request('/api/v0/cluster/development/hosts')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual(
-            json.loads(self.ahostset),
-            json.loads(body[0]))
-
-        # Verify bad cluster name returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request('/api/v0/cluster/bogus/hosts')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad cluster name returns the proper result
+            _publish.return_value = [[
+                [], etcd.EtcdKeyNotFound]]
+            body = self.simulate_request('/api/v0/cluster/bogus/hosts')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
     def test_cluster_hosts_overwrite(self):
         """
         Verify overwriting a cluster host list.
         """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify setting host list works with a proper request
+            _publish.return_value = [[MagicMock(
+                value=self.etcd_cluster), None]]
+            # self.datasource.get.return_value = MagicMock(
+            #    value=self.etcd_cluster)
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts', method='PUT',
+                body='{"old": ["10.2.0.2"], "new": ["10.2.0.2", "10.2.0.3"]}')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify setting host list works with a proper request
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts', method='PUT',
-            body='{"old": ["10.2.0.2"], "new": ["10.2.0.2", "10.2.0.3"]}')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(1, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad request (KeyError) returns the proper result
+            _publish.return_value = [[[], KeyError()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts', method='PUT',
+                body='{"new": ["10.2.0.2", "10.2.0.3"]}')
+            self.assertEqual(falcon.HTTP_400, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify bad request (KeyError) returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts', method='PUT',
-            body='{"new": ["10.2.0.2", "10.2.0.3"]}')
-        self.assertEquals(0, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_400, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad request (TypeError) returns the proper result
+            _publish.return_value = [[[], TypeError()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts', method='PUT',
+                body='["10.2.0.2", "10.2.0.3"]')
+            self.assertEqual(falcon.HTTP_400, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify bad request (TypeError) returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts', method='PUT',
-            body='["10.2.0.2", "10.2.0.3"]')
-        self.assertEquals(0, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_400, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad cluster name returns the proper result
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/bogus/hosts', method='PUT',
+                body='{"old": ["10.2.0.2"], "new": ["10.2.0.2", "10.2.0.3"]}')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify bad cluster name returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request(
-            '/api/v0/cluster/bogus/hosts', method='PUT',
-            body='{"old": ["10.2.0.2"], "new": ["10.2.0.2", "10.2.0.3"]}')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
-
-        # Verify host list conflict returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.side_effect = None
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts', method='PUT',
-            body='{"old": [], "new": ["10.2.0.2", "10.2.0.3"]}')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_409, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify host list conflict returns the proper result
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts', method='PUT',
+                body='{"old": [], "new": ["10.2.0.2", "10.2.0.3"]}')
+            self.assertEqual(falcon.HTTP_409, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
 
 class Test_ClusterSingleHostResource(TestCase):
@@ -468,82 +463,70 @@ class Test_ClusterSingleHostResource(TestCase):
         """
         Verify host membership in a cluster.
         """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify member host returns the proper result
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts/10.2.0.2')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify member host returns the proper result
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts/10.2.0.2')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify non-member host returns the proper result
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts/10.9.9.9')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify non-member host returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts/10.9.9.9')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
-
-        # Verify bad cluster name returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request(
-            '/api/v0/cluster/bogus/hosts/10.2.0.2')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad cluster name returns the proper result
+            _publish.return_value = [[
+                [], etcd.EtcdKeyNotFound()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/bogus/hosts/10.2.0.2')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
     def test_cluster_host_insert(self):
         """
         Verify insertion of host in a cluster.
         """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify inserting host returns the proper result
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/developent/hosts/10.2.0.3', method='PUT')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify inserting host returns the proper result
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/developent/hosts/10.2.0.3', method='PUT')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(1, self.datasource.write.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
-
-        # Verify bad cluster name returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request(
-            '/api/v0/cluster/bogus/hosts/10.2.0.3', method='PUT')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad cluster name returns the proper result
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/bogus/hosts/10.2.0.3', method='PUT')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
     def test_cluster_host_delete(self):
         """
         Verify deletion of host in a cluster.
         """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify deleting host returns the proper result
+            _publish.return_value = [[
+                MagicMock(value=self.etcd_cluster), None]]
+            body = self.simulate_request(
+                '/api/v0/cluster/development/hosts/10.2.0.2', method='DELETE')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
-        # Verify deleting host returns the proper result
-        self.datasource.get.return_value = MagicMock(value=self.etcd_cluster)
-        body = self.simulate_request(
-            '/api/v0/cluster/development/hosts/10.2.0.2', method='DELETE')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(1, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
-
-        # Verify bad cluster name returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.set.reset_mock()
-        self.datasource.get.side_effect = etcd.EtcdKeyNotFound
-        body = self.simulate_request(
-            '/api/v0/cluster/bogus/hosts/10.2.0.2', method='DELETE')
-        self.assertEquals(1, self.datasource.get.call_count)
-        self.assertEquals(0, self.datasource.set.call_count)
-        self.assertEqual(falcon.HTTP_404, self.srmock.status)
-        self.assertEqual({}, json.loads(body[0]))
+            # Verify bad cluster name returns the proper result
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+            body = self.simulate_request(
+                '/api/v0/cluster/bogus/hosts/10.2.0.2', method='DELETE')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
 
 
 class Test_ClusterUpgrade(TestCase):
@@ -591,23 +574,27 @@ class Test_ClusterUpgradeResource(TestCase):
         """
         Verify retrieving a cluster upgrade.
         """
-        # Verify if the cluster upgrade exists the data is returned
-        self.datasource.get.return_value = MagicMock(value=self.aupgrade)
-        body = self.simulate_request('/api/v0/cluster/development/upgrade')
-        self.assertEquals(2, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_200, self.srmock.status)
-        self.assertEqual(json.loads(self.aupgrade), json.loads(body[0]))
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            # Verify if the cluster upgrade exists the data is returned
+            self.datasource.get.return_value = MagicMock(
+                'etcd.EtcdResult', value=self.etcd_cluster)
+            _publish.return_value = [[MagicMock(value=self.aupgrade), None]]
+            body = self.simulate_request('/api/v0/cluster/development/upgrade')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+            self.assertEqual(json.loads(self.aupgrade), json.loads(body[0]))
 
-        # Verify no cluster upgrade returns the proper result
-        self.datasource.get.reset_mock()
-        self.datasource.get.side_effect = (None, etcd.EtcdKeyNotFound)
+            # Verify no cluster upgrade returns the proper result
+            _publish.reset_mock()
+            _publish.side_effect = (
+                [[MagicMock(
+                    'etcd.EtcdResult', value=self.etcd_cluster), None]],
+                [[[], etcd.EtcdKeyNotFound()]])
 
-        body = self.simulate_request('/api/v0/cluster/development/upgrade')
-        self.assertEquals(2, self.datasource.get.call_count)
-        self.assertEqual(falcon.HTTP_204, self.srmock.status)
-        self.assertEqual([], body)  # Empty data
+            body = self.simulate_request('/api/v0/cluster/development/upgrade')
+            self.assertEqual(falcon.HTTP_204, self.srmock.status)
+            self.assertEqual([], body)  # Empty data
 
-    def test_cluster_create(self):
+    def test_cluster_upgrade_create(self):
         """
         Verify creating a cluster.
         """
@@ -615,11 +602,18 @@ class Test_ClusterUpgradeResource(TestCase):
         # Process is patched because we don't want to exec the subprocess
         # during unittesting
         with contextlib.nested(
+                mock.patch('cherrypy.engine.publish'),
                 mock.patch('etcd.Client'),
-                mock.patch('commissaire.handlers.clusters.Process')):
+                mock.patch('commissaire.handlers.clusters.Process')) as (
+                    _publish, _, _):
             self.datasource.get.side_effect = (
                 MagicMock(value=self.etcd_cluster),
                 etcd.EtcdKeyNotFound)
+
+            _publish.side_effect = (
+                [[MagicMock(value=self.etcd_cluster), None]],
+                [[[], etcd.EtcdKeyNotFound]],
+                [[MagicMock(etcd.EtcdResult, value=self.aupgrade), None]])
 
             # Verify sending no/bad data returns a 400
             for put_data in (None, '{"nothing": "here"}"'):

--- a/test/test_handlers_status.py
+++ b/test/test_handlers_status.py
@@ -25,7 +25,7 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import status
 from commissaire.middleware import JSONify
-from commissaire.jobs import POOLS, PROCS
+from commissaire.jobs import PROCS
 
 
 class Test_Status(TestCase):
@@ -45,7 +45,7 @@ class Test_Status(TestCase):
 
         # Make sure a Cluster is accepted as expected
         status_model = status.Status(
-            etcd={}, investigator={}, clusterexecpool={})
+            etcd={}, investigator={})
         self.assertEquals(type(str()), type(status_model.to_json()))
 
 
@@ -54,9 +54,7 @@ class Test_StatusResource(TestCase):
     Tests for the Status resource.
     """
     astatus = ('{"etcd": {"status": "OK"}, "investigator": {"status": '
-               '"OK", "info": {"size": 1, "in_use": 1, "errors": []}}, '
-               '"clusterexecpool": {"status": "OK", "info": '
-               '{"size": 1, "in_use": 1, "errors": []}}}')
+               '"OK", "info": {"size": 1, "in_use": 1, "errors": []}}}')
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
@@ -74,13 +72,6 @@ class Test_StatusResource(TestCase):
         child = MagicMock(value='')
         self.return_value._children = [child]
         self.return_value.leaves = self.return_value._children
-
-        for pool in ('clusterexecpool', ):
-            POOLS[pool] = MagicMock(
-                'gevent.pool.Pool',
-                size=1,
-                free_count=lambda: 0,
-                greenlets=[])
 
         for proc in ('investigator', ):
             PROCS[proc] = MagicMock(

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -59,8 +59,9 @@ class Test_JobsInvestigator(TestCase):
         Verify the investigator.
         """
         with contextlib.nested(
+                mock.patch('cherrypy.engine.publish'),
                 mock.patch('commissaire.transport.ansibleapi.Transport'),
-                mock.patch('etcd.Client')) as (_tp, _store):
+                mock.patch('etcd.Client')) as (_publish, _tp, _store):
             _tp().get_info.return_value = (
                 0,
                 {
@@ -72,11 +73,8 @@ class Test_JobsInvestigator(TestCase):
             )
 
             q = Queue()
-            store = _store()
-            store.get = MagicMock('get')
-            store.get.return_value = MagicMock(value=self.etcd_host)
-            store.set = MagicMock('set')
-            store.set.return_value = self.etcd_host
+            _publish.return_value = [[
+                MagicMock('etcd.EtcdResult', value=self.etcd_host), None]]
 
             to_investigate = {
                 'address': '10.0.0.2',
@@ -94,7 +92,6 @@ class Test_JobsInvestigator(TestCase):
             }
 
             q.put_nowait((to_investigate, ssh_priv_key))
-            investigator(q, connection_config, {}, True)
+            investigator(q, connection_config, True)
 
-            self.assertEquals(1, store.get.call_count)
-            self.assertEquals(2, store.set.call_count)
+            self.assertEquals(3, _publish.call_count)

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -24,7 +24,7 @@ from . import TestCase
 from commissaire.compat.urlparser import urlparse
 
 from commissaire.jobs.investigator import clean_up_key, investigator
-from gevent.queue import Queue
+from Queue import Queue
 from mock import MagicMock
 
 
@@ -60,7 +60,7 @@ class Test_JobsInvestigator(TestCase):
         """
         with contextlib.nested(
                 mock.patch('commissaire.transport.ansibleapi.Transport'),
-                mock.patch('etcd.Client')) as (_tp, _client):
+                mock.patch('etcd.Client')) as (_tp, _store):
             _tp().get_info.return_value = (
                 0,
                 {
@@ -72,11 +72,11 @@ class Test_JobsInvestigator(TestCase):
             )
 
             q = Queue()
-            client = _client()
-            client.get = MagicMock('get')
-            client.get.return_value = MagicMock(value=self.etcd_host)
-            client.set = MagicMock('set')
-            client.set.return_value = self.etcd_host
+            store = _store()
+            store.get = MagicMock('get')
+            store.get.return_value = MagicMock(value=self.etcd_host)
+            store.set = MagicMock('set')
+            store.set.return_value = self.etcd_host
 
             to_investigate = {
                 'address': '10.0.0.2',
@@ -96,5 +96,5 @@ class Test_JobsInvestigator(TestCase):
             q.put_nowait((to_investigate, ssh_priv_key))
             investigator(q, connection_config, {}, True)
 
-            self.assertEquals(1, client.get.call_count)
-            self.assertEquals(2, client.set.call_count)
+            self.assertEquals(1, store.get.call_count)
+            self.assertEquals(2, store.set.call_count)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -16,12 +16,12 @@
 Test cases for the commissaire.script module.
 """
 
+import mock
 import falcon
 import etcd
 import os.path
 
 from . import TestCase
-from mock import MagicMock
 from commissaire import script
 
 
@@ -34,10 +34,12 @@ class Test_CreateApp(TestCase):
         """
         Verify cli_etcd_or_default works with cli input.
         """
-        store = MagicMock(get=MagicMock(side_effect=etcd.EtcdKeyNotFound))
-        app = script.create_app(store, os.path.realpath('../conf/users.json'))
-        self.assertTrue(isinstance(app, falcon.API))
-        self.assertEquals(2, len(app._middleware))
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound]]
+            app = script.create_app(
+                None, os.path.realpath('../conf/users.json'))
+            self.assertTrue(isinstance(app, falcon.API))
+            self.assertEquals(2, len(app._middleware))
 
 
 class Test_ParseUri(TestCase):


### PR DESCRIPTION
- No more greenlets
- No more gevent
- CherryPy now used as the application server
- Moves calls from directly using the ```etcd.Client``` to utilizing the CherryPy plugin bus