### PR TITLE
doc: Remove module first syntax from generated docs.

### DIFF
--- a/doc/apidoc/commissaire.authentication.rst
+++ b/doc/apidoc/commissaire.authentication.rst
@@ -1,11 +1,6 @@
 commissaire.authentication package
 ==================================
 
-.. automodule:: commissaire.authentication
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -13,3 +8,10 @@ Submodules
 
    commissaire.authentication.httpauth
 
+Module contents
+---------------
+
+.. automodule:: commissaire.authentication
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.compat.rst
+++ b/doc/apidoc/commissaire.compat.rst
@@ -1,11 +1,6 @@
 commissaire.compat package
 ==========================
 
-.. automodule:: commissaire.compat
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -15,3 +10,10 @@ Submodules
    commissaire.compat.exception
    commissaire.compat.urlparser
 
+Module contents
+---------------
+
+.. automodule:: commissaire.compat
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.containermgr.kubernetes.rst
+++ b/doc/apidoc/commissaire.containermgr.kubernetes.rst
@@ -1,8 +1,10 @@
 commissaire.containermgr.kubernetes package
 ===========================================
 
+Module contents
+---------------
+
 .. automodule:: commissaire.containermgr.kubernetes
     :members:
     :undoc-members:
     :show-inheritance:
-

--- a/doc/apidoc/commissaire.containermgr.rst
+++ b/doc/apidoc/commissaire.containermgr.rst
@@ -1,11 +1,6 @@
 commissaire.containermgr package
 ================================
 
-.. automodule:: commissaire.containermgr
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Subpackages
 -----------
 
@@ -13,3 +8,10 @@ Subpackages
 
     commissaire.containermgr.kubernetes
 
+Module contents
+---------------
+
+.. automodule:: commissaire.containermgr
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.handlers.rst
+++ b/doc/apidoc/commissaire.handlers.rst
@@ -1,11 +1,6 @@
 commissaire.handlers package
 ============================
 
-.. automodule:: commissaire.handlers
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -17,3 +12,10 @@ Submodules
    commissaire.handlers.status
    commissaire.handlers.util
 
+Module contents
+---------------
+
+.. automodule:: commissaire.handlers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.jobs.rst
+++ b/doc/apidoc/commissaire.jobs.rst
@@ -1,11 +1,6 @@
 commissaire.jobs package
 ========================
 
-.. automodule:: commissaire.jobs
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -14,3 +9,10 @@ Submodules
    commissaire.jobs.clusterexec
    commissaire.jobs.investigator
 
+Module contents
+---------------
+
+.. automodule:: commissaire.jobs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.oscmd.rst
+++ b/doc/apidoc/commissaire.oscmd.rst
@@ -1,11 +1,6 @@
 commissaire.oscmd package
 =========================
 
-.. automodule:: commissaire.oscmd
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -16,3 +11,10 @@ Submodules
    commissaire.oscmd.redhat
    commissaire.oscmd.rhel
 
+Module contents
+---------------
+
+.. automodule:: commissaire.oscmd
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.rst
+++ b/doc/apidoc/commissaire.rst
@@ -1,11 +1,6 @@
 commissaire package
 ===================
 
-.. automodule:: commissaire
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Subpackages
 -----------
 
@@ -34,3 +29,10 @@ Submodules
    commissaire.resource
    commissaire.script
 
+Module contents
+---------------
+
+.. automodule:: commissaire
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.transport.rst
+++ b/doc/apidoc/commissaire.transport.rst
@@ -1,11 +1,6 @@
 commissaire.transport package
 =============================
 
-.. automodule:: commissaire.transport
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -13,3 +8,10 @@ Submodules
 
    commissaire.transport.ansibleapi
 
+Module contents
+---------------
+
+.. automodule:: commissaire.transport
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
With the merge of 91b470c149190d5f523835fbf13f8f7446c324c2 doc/apidocs/
are no longer module first. This updates the generated files to the
proper format.