### PR TITLE
[merged] commctl: Add 'list clusters' and 'list hosts' commands

### DIFF
--- a/src/commissaire/client_script.py
+++ b/src/commissaire/client_script.py
@@ -167,6 +167,33 @@ class Client(object):
         uri = '{0}/api/v0/cluster/{1}/upgrade'.format(self.endpoint, name)
         return self._put(uri, {'upgrade_to': kwargs['upgrade_to']})
 
+    def list_clusters(self, **kwargs):
+        """
+        Attempts to list available clusters.
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+        """
+        uri = '{0}/api/v0/clusters'.format(self.endpoint)
+        return self._get(uri)
+
+    def list_hosts(self, name, **kwargs):
+        """
+        Attempts to list all hosts or hosts in particular cluster.
+
+        :param kwargs: Any other keyword arguments
+        :type kwargs: dict
+        """
+        if not name:
+            uri = '{0}/api/v0/hosts'.format(self.endpoint)
+            result = self._get(uri)
+            if result:
+                result = [host['address'] for host in result]
+            return result
+        else:
+            uri = '{0}/api/v0/cluster/{1}/hosts'.format(self.endpoint, name)
+            return self._get(uri)
+
 
 def main():
     """
@@ -214,6 +241,17 @@ def main():
         '-n', '--name', required=True, help='Name of the cluster')
     upgrade_parser.add_argument(
         '-u', '--upgrade-to', required=True, help='Version to upgrade to')
+
+    list_parser = sp.add_parser('list')
+    list_sp = list_parser.add_subparsers(dest='sub_command')
+
+    list_clusters_parser = list_sp.add_parser('clusters')
+    # No arguments for 'list clusters' at present.
+
+    list_hosts_parser = list_sp.add_parser('hosts')
+    list_hosts_parser.add_argument(
+        '-n', '--name', required=False,
+        help='Name of the cluster (omit to list all hosts)')
 
     args = parser.parse_args()
 

--- a/src/commissaire/client_script.py
+++ b/src/commissaire/client_script.py
@@ -181,6 +181,8 @@ class Client(object):
         """
         Attempts to list all hosts or hosts in particular cluster.
 
+        :param name: The name of the cluster (optional)
+        :type name: str or None
         :param kwargs: Any other keyword arguments
         :type kwargs: dict
         """

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -80,3 +80,26 @@ class TestClientScript(TestCase):
                 client_script.main()
                 self.assertEquals(1, _put.call_count)
                 _put.reset_mock()
+
+    def test_client_script_list(self):
+        """
+        Verify use cases for the client_script list command.
+        """
+        sys.argv = ['', 'list']
+        with contextlib.nested(
+                mock.patch('requests.Session.get'),
+                mock.patch('os.path.realpath')) as (_get, _realpath):
+            _realpath.return_value = self.conf
+            for subcmd, content in ((['clusters'], '[]'),
+                                    (['hosts'], '{}'),
+                                    (['hosts', '-n', 'test'], '[]')):
+                mock_return = requests.Response()
+                mock_return._content = content
+                mock_return.status_code = 200
+                _get.return_value = mock_return
+
+                sys.argv[2:] = subcmd
+                print sys.argv
+                client_script.main()
+                self.assertEquals(1, _get.call_count)
+                _get.reset_mock()


### PR DESCRIPTION
In playing with `commctl` last week, the very first thing I tried was querying what clusters and hosts I had already set up from previous test sessions.  Seems the tool is missing this, so I'm plugging the gap with some new commands.

`commctl list clusters` takes no arguments.

`commctl list hosts` takes an optional `-n` / `--name` argument, which restricts the list to the given cluster name.

I opted for a new verb `list` instead of extending `get` because I felt it was more intuitive.  Whereas `get` will return detailed status info, `list` will return a compact list with no details.