### PR TITLE
[merged] Move from pep8 to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"
 script:
-  - "pep8 -r src/"
+  - "python setup.py flake8"
   - "python setup.py nosetests"
 notifications:
   email: false

--- a/contrib/package/rpm/commissaire.spec
+++ b/contrib/package/rpm/commissaire.spec
@@ -17,7 +17,7 @@ BuildRequires:  python-sphinx
 BuildRequires:  python-coverage
 BuildRequires:  python-mock
 BuildRequires:  python-nose
-BuildRequires:  python-pep8
+BuildRequires:  python-flake8
 BuildRequires:  pkgconfig(systemd)
 
 # XXX: Waiting on python2-python-etcd to pass review
@@ -91,6 +91,7 @@ install -D contrib/systemd/commissaire.service %{buildroot}%{_unitdir}/commissai
 %changelog
 * Tue Mar 29 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-4
 - Added author files
+- Changed from pep8 to flake8
 
 * Thu Mar 17 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-3
 - Now using cherrypy rather than gevent.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
-[pep8]
+[flake8]
 ignore = E402
+exclude = test/*
+#max-complexity = 20
 
 [nosetests]
 verbosity=2

--- a/src/commissaire/client_script.py
+++ b/src/commissaire/client_script.py
@@ -247,7 +247,7 @@ def main():
     list_parser = sp.add_parser('list')
     list_sp = list_parser.add_subparsers(dest='sub_command')
 
-    list_clusters_parser = list_sp.add_parser('clusters')
+    list_sp.add_parser('clusters')
     # No arguments for 'list clusters' at present.
 
     list_hosts_parser = list_sp.add_parser('hosts')

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -140,7 +140,7 @@ class HostResource(Resource):
         """
         resp.body = '{}'
         try:
-            host = self.store.delete(util.etcd_host_key(address))
+            self.store.delete(util.etcd_host_key(address))
             resp.status = falcon.HTTP_410
         except etcd.EtcdKeyNotFound:
             resp.status = falcon.HTTP_404

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -18,7 +18,6 @@ The clusterexec job.
 
 import cherrypy
 import datetime
-import etcd
 import json
 import logging
 import tempfile

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 behave
 requests
 nose
-pep8
+flake8
 coverage
 mock


### PR DESCRIPTION
This PR moves us from using ```pep8``` to ```flake8``` for code quality.