### PR TITLE
[merged] Distinguish Fedora-Atomic from Fedora

### DIFF
--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -277,9 +277,9 @@ class Transport:
             space += x['size_total']
         facts['space'] = space
 
-        # Special case for atomic: Since Atomic doesn't advertise itself and
-        # instead calls itself 'redhat' we need to check for 'atomicos'
-        # in other ansible_cmdline facts
+        # Special case for atomic: Since Atomic doesn't advertise itself
+        # and instead calls itself 'redhat' or 'fedora' we need to check
+        # for 'atomicos' in other ansible_cmdline facts
         if facts['os'] == 'redhat':
             self.logger.debug(
                 'Found os of redhat. Checking for special atomic case...')
@@ -287,6 +287,16 @@ class Transport:
                 'ansible_cmdline', {}).get('BOOT_IMAGE', '')
             root_mapper = fact_cache.get('ansible_cmdline', {}).get('root', '')
             if (boot_image.startswith('/ostree/rhel-atomic-host') or
+                    'atomicos' in root_mapper):
+                facts['os'] = 'atomic'
+            self.logger.debug('Facts: {0}'.format(facts))
+        if facts['os'] == 'fedora':
+            self.logger.debug(
+                'Found os of fedora. Checking for special atomic case...')
+            boot_image = fact_cache.get(
+                'ansible_cmdline', {}).get('BOOT_IMAGE', '')
+            root_mapper = fact_cache.get('ansible_cmdline', {}).get('root', '')
+            if (boot_image.startswith('/ostree/fedora-atomic') or
                     'atomicos' in root_mapper):
                 facts['os'] = 'atomic'
             self.logger.debug('Facts: {0}'.format(facts))


### PR DESCRIPTION
I happen to be testing on Fedora-Atomic instead of RHEL-Atomic, and the `bootstrap` playbook is trying to install packages.