### PR TITLE
[merged] Support CentOS

### DIFF
--- a/src/commissaire/oscmd/centos.py
+++ b/src/commissaire/oscmd/centos.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://
+"""
+CentOS commands.
+"""
+
+from commissaire.oscmd.rhel import OSCmd as OSCmdBase
+
+
+class OSCmd(OSCmdBase):
+    """
+    Commmands for CentOS.
+    """
+
+    #: The type of Operating System
+    os_type = 'centos'

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -291,25 +291,22 @@ class Transport:
         facts['space'] = space
 
         # Special case for atomic: Since Atomic doesn't advertise itself
-        # and instead calls itself 'redhat' or 'fedora' we need to check
-        # for 'atomicos' in other ansible_cmdline facts
-        if facts['os'] == 'redhat':
+        # and instead calls itself 'redhat' or 'centos' or 'fedora', we
+        # need to check for 'atomicos' in other ansible_cmdline facts.
+        atomic_os_types = {
+            'redhat': '/ostree/rhel-atomic-host',
+            'centos': '/ostree/centos-atomic-host',
+            'fedora': '/ostree/fedora-atomic'
+        }
+        os_type = facts['os']
+        if os_type in atomic_os_types:
             self.logger.debug(
-                'Found os of redhat. Checking for special atomic case...')
+                'Found os of {0}. Checking for special '
+                'atomic case...'.format(os_type))
             boot_image = fact_cache.get(
                 'ansible_cmdline', {}).get('BOOT_IMAGE', '')
             root_mapper = fact_cache.get('ansible_cmdline', {}).get('root', '')
-            if (boot_image.startswith('/ostree/rhel-atomic-host') or
-                    'atomicos' in root_mapper):
-                facts['os'] = 'atomic'
-            self.logger.debug('Facts: {0}'.format(facts))
-        if facts['os'] == 'fedora':
-            self.logger.debug(
-                'Found os of fedora. Checking for special atomic case...')
-            boot_image = fact_cache.get(
-                'ansible_cmdline', {}).get('BOOT_IMAGE', '')
-            root_mapper = fact_cache.get('ansible_cmdline', {}).get('root', '')
-            if (boot_image.startswith('/ostree/fedora-atomic') or
+            if (boot_image.startswith(atomic_os_types[os_type]) or
                     'atomicos' in root_mapper):
                 facts['os'] = 'atomic'
             self.logger.debug('Facts: {0}'.format(facts))


### PR DESCRIPTION
Just because.

As an aside, in trying an older CentOS image, TIL that cloud-init only *just recently* moved to Python3.  So my `part-handler.py` script needs to support 2 and 3 after all, and the older `ConfigParser` API is making me want to kill puppies.  Thinking about moving to JSON...