### PR TITLE
[merged] cloud-init: Change config data format to JSON

### DIFF
--- a/contrib/cloud-init/commissaire.txt
+++ b/contrib/cloud-init/commissaire.txt
@@ -1,23 +1,7 @@
-# Host name of the commissaire service.
-COMMISSAIRE_SERVER_HOST = master.example.com
-
-# (optional) Port number of the commissaire service. Defaults to 8000.
-COMMISSAIRE_SERVER_PORT = 8000
-
-# (optional) User name to use for commissaire service authentication.
-COMMISSAIRE_SERVER_USERNAME = user
-
-# (optional) Password to use for commissaire service authentication.
-COMMISSAIRE_SERVER_PASSWORD = 12345
-
-# (optional) Boolean value indicates whether to connect to the
-# service using Transport Layer Security (TLS). Defaults to true.
-COMMISSAIRE_SERVER_SECURE = true
-
-# (optional) The name of the cluster to join.
-COMMISSAIRE_CLUSTER = mycluster
-
-# (optional) The private SSH key file for the root account of this
-# host. Defaults to '/root/.ssh/id_rsa' and, if necessary, generates
-# a public/private key pair with no passphrase.
-#ROOT_SSH_KEY_PATH = /root/.ssh/id_rsa
+{
+  "endpoint": "https://master.example.com:8000",
+  "username": "user",                             # Optional
+  "password": "12345",                            # Optional
+  "cluster": "mycluster",                         # Optional
+  "root_ssh_key_path": "/root/.ssh/id_rsa"        # Optional
+}

--- a/contrib/cloud-init/part-handler.py
+++ b/contrib/cloud-init/part-handler.py
@@ -4,30 +4,21 @@
 #  Handles a 'text/x-commissaire-host' part of a cloud-init user data file.
 #  Registers the host with a Commissaire server using the given parameters.
 #
-#  Parameter syntax is simple 'KEY = VALUE' lines.
+#  Data format is a JSON object with the following members:
 #
-#  Recognized (case-insensitive) keys are:
+#  "endpoint"
+#    Base URI of the Commissaire service.
 #
-#  COMMISSAIRE_SERVER_HOST
-#    The host name of the Commissaire service.
-#
-#  COMMISSAIRE_SERVER_PORT  (optional)
-#    The port number of the Commissaire service.  Defaults to 8000.
-#
-#  COMMISSAIRE_SERVER_USERNAME  (optional)
+#  "username"  (optional)
 #    The user name to use for Commissaire service authentication.
 #
-#  COMMISSAIRE_SERVER_PASSWORD  (optional)
+#  "password"  (optional)
 #    The password to use for Commissaire service authentication.
 #
-#  COMMISSAIRE_SERVER_SECURE  (optional)
-#    Boolean value indicates whether to connect to the Commissaire
-#    service using Transport Layer Security (TLS).  Defaults to true.
-#
-#  COMMISSAIRE_CLUSTER  (optional)
+#  "cluster"  (optional)
 #    The name of the cluster to join.
 #
-#  ROOT_SSH_KEY_PATH  (optional)
+#  "root_ssh_key_path"  (optional)
 #    The private SSH key file for the root account of this host.
 #    Defaults to '/root/.ssh/id_rsa' and, if necessary, generates
 #    a public/private key pair with no passphrase.
@@ -65,13 +56,15 @@
 # part so cloud-init knows how to handle the text/x-commissaire-host part.
 #
 
+from __future__ import print_function
+
 import sys
 import stat
 import os
 import os.path
-import configparser
 import subprocess
 import base64
+import json
 
 # 3rd party module
 import requests
@@ -91,74 +84,66 @@ def handle_part(data, ctype, filename, payload):
     # Re-raise any exceptions so they get logged, but also print a
     # useful message before doing so to help ascertain the problem.
 
-    parser = configparser.ConfigParser()
-
     try:
-        payload_with_section = '[DEFAULT]\n' + payload
-        parser.read_string(payload_with_section, source=filename)
-    except configparser.ParsingError as err:
-        print(str(err), file=sys.stderr)
-        raise
-
-    keys = parser['DEFAULT']
-
-    if not 'COMMISSAIRE_SERVER_HOST' in keys:
-        print('{0}: Missing required key COMMISSAIRE_SERVER_HOST'.
-            format(filename), file=sys.stderr)
+        config = json.loads(payload)
+        assert type(config) is dict
+    except (AssertionError, ValueError):
+        print('{0}: {1} data must be a JSON object'.format(filename, ctype),
+              file=sys.stderr)
         return
 
-    host = keys.get('COMMISSAIRE_SERVER_HOST')
-    port = keys.get('COMMISSAIRE_SERVER_PORT', 8000)
-    user = keys.get('COMMISSAIRE_SERVER_USERNAME')
-    pwrd = keys.get('COMMISSAIRE_SERVER_PASSWORD')
-    tls = keys.getboolean('COMMISSAIRE_SERVER_SECURE')
-    cluster = keys.get('COMMISSAIRE_CLUSTER')
-    keyfile = keys.get('ROOT_SSH_KEY_PATH', '/root/.ssh/id_rsa')
+    if 'endpoint' not in config:
+        print('{0}: Missing required "endpoint" URI'.format(filename),
+              file=sys.stderr)
+        return
 
-    if keyfile:
-        if not os.path.isfile(keyfile):
-            try:
-                subprocess.check_call(
-                    ['/usr/bin/ssh-keygen', '-q', '-N', '',
-                     '-t', 'rsa', '-f', keyfile])
-            except FileNotFoundError:
-                print('Missing /usr/bin/ssh-keygen', file=sys.stderr)
-                raise
-            except subprocess.CalledProcessError as ex:
-                print(str(ex), file=sys.stderr)
-                raise
+    endpoint = config.get('endpoint')
+    username = config.get('username')
+    password = config.get('password')
+    cluster = config.get('cluster')
+    keyfile = config.get('root_ssh_key_path', '/root/.ssh/id_rsa')
 
+    if not os.path.isfile(keyfile):
         try:
-            authorized_keys = '/root/.ssh/authorized_keys'
-            with open(keyfile + '.pub') as inpf:
-                # If creating a new file, set mode to 0600.
-                fd = os.open(authorized_keys,
-                             os.O_WRONLY | os.O_APPEND | os.O_CREAT,
-                             stat.S_IRUSR | stat.S_IWUSR)
-                with os.fdopen(fd, 'a') as outf:
-                    outf.writelines(inpf.readlines())
-        except Exception as ex:
+            subprocess.check_call(
+                ['/usr/bin/ssh-keygen', '-q', '-N', '',
+                 '-t', 'rsa', '-f', keyfile])
+        except FileNotFoundError:
+            print('Missing /usr/bin/ssh-keygen', file=sys.stderr)
+            raise
+        except subprocess.CalledProcessError as ex:
             print(str(ex), file=sys.stderr)
             raise
 
-    json = {}
+    try:
+        authorized_keys = '/root/.ssh/authorized_keys'
+        with open(keyfile + '.pub') as inpf:
+            # If creating a new file, set mode to 0600.
+            fd = os.open(authorized_keys,
+                         os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+                         stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, 'a') as outf:
+                outf.writelines(inpf.readlines())
+    except Exception as ex:
+        print(str(ex), file=sys.stderr)
+        raise
+
+    body = {}
 
     try:
         with open(keyfile, 'rb') as f:
             b64_bytes = base64.b64encode(f.read())
-            json['ssh_priv_key'] = b64_bytes.decode()
+            body['ssh_priv_key'] = b64_bytes.decode()
     except Exception as ex:
         print(str(ex), file=sys.stderr)
         raise
 
     if cluster:
-        json['cluster'] = cluster
+        body['cluster'] = cluster
 
-    url = '{0}://{1}:{2}/api/v0/host/'.format(
-        'https' if tls else 'http', host, port)
+    uri = '{0}/api/v0/host'.format(endpoint)
+    auth = (username, password) if username and password else None
 
-    auth = (user, pwrd) if user and pwrd else None
-
-    resp = requests.put(url, json=json, auth=auth)
+    resp = requests.put(uri, json=body, auth=auth)
     print('Commissaire response: {0} {1}'.format(
         resp.status_code, resp.reason))

--- a/doc/cloud_init.rst
+++ b/doc/cloud_init.rst
@@ -8,8 +8,8 @@ to help automatically register hosts to the commissaire server during
 bootup by way of cloud-init.
 
 The script is intended to be embedded or referenced by an ``#include``
-directive in a multi-part ``user-data`` file, along with a simple config
-file containing the server parameters.
+directive in a multi-part ``user-data`` file, along with a simple JSON
+config file containing the server parameters.
 
 Here's a sample config file showing all recognized parameters:
 


### PR DESCRIPTION
Turns out this needs to work with both Python 2 and 3, and dealing with the older `ConfigParser` class is painful.  The new format more closely matches that of `.commissaire.json` for `commctl`.  Consistency!