### PR TITLE
[merged] setup.py: Remove need for string import.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,13 @@
 Source build and installation script.
 """
 
-import string
-
 from setuptools import setup, find_packages
 
 
 def extract_names(filename):
     names = ''
     with open(filename, 'r') as m:
-        names = ', '.join(map(string.strip, m.readlines()))
+        names = ', '.join([x.strip() for x in m.readlines()])
     return names
 
 


### PR DESCRIPTION
In Python 3 string no longer has the strip function while a string
instance does. This removes the import and use of string in setup.py and
replaces it with each instances method.