### PR TITLE
[merged] doc: Added docclass to latex build.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -227,8 +227,9 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   (master_doc, 'commissaire.tex', u'commissaire Documentation',
-   u'See CONTRIBUTORS'),
+   u'See CONTRIBUTORS', 'manual'),
 ]
+
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.


### PR DESCRIPTION
RTD is currently failing because of missing ```docclass```. This adds it to the documentation config.