### PR TITLE
[merged] fix: bootstrap playbook now restarts services.

### DIFF
--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -62,7 +62,7 @@
       service:
         name: "{{ item }}"
         enabled: yes
-        state: started
+        state: restarted
       with_items:
         - "{{ commissaire_flannel_service }}"
         - "{{ commissaire_docker_service }}"


### PR DESCRIPTION
According to Ansible documentation the started state is idempotent.
@mbarnes ran into an issue where if the services had been started
already the new configuration files were never picked up. This change
uses the restarted state to ensure that the configuration is always
read. This closes #88.