### PR TITLE
[merged] Fix a typo in clusterexec.py

### DIFF
--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -421,7 +421,7 @@ class ClusterRestartResource(Resource):
             'finished_at': None
         }
         cluster_restart = ClusterRestart(**cluster_restart_default)
-        cherrypy.engine.publish('store-set', cluster_restart.to_json())
+        cherrypy.engine.publish('store-save', key, cluster_restart.to_json())
         resp.status = falcon.HTTP_201
         req.context['model'] = cluster_restart
 
@@ -533,6 +533,6 @@ class ClusterUpgradeResource(Resource):
         }
         cluster_upgrade = ClusterUpgrade(**cluster_upgrade_default)
         cherrypy.engine.publish(
-            'store-save', key, cluster_upgrade.to_json())[0]
+            'store-save', key, cluster_upgrade.to_json())
         resp.status = falcon.HTTP_201
         req.context['model'] = cluster_upgrade

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -65,7 +65,7 @@ def clusterexec(cluster_name, command):
     cherrypy.engine.publish(
         'store-save',
         '/commissaire/cluster/{0}/{1}'.format(cluster_name, command),
-        json.dumps(cluster_status))[0]
+        json.dumps(cluster_status))
 
     # Collect all host addresses in the cluster
     etcd_resp, error = cherrypy.engine.publish(
@@ -108,7 +108,7 @@ def clusterexec(cluster_name, command):
 
         cluster_status['in_process'].append(a_host['address'])
         cherrypy.engine.publish(
-            'store-set',
+            'store-save',
             '/commissaire/cluster/{0}/{1}'.format(cluster_name, command),
             json.dumps(cluster_status))
 
@@ -148,9 +148,9 @@ def clusterexec(cluster_name, command):
                 a_host['address'], command, cluster_name))
 
         cherrypy.engine.publish(
-            'store-set',
+            'store-save',
             '/commissaire/cluster/{0}/{1}'.format(cluster_name, command),
-            json.dumps(cluster_status))[0]
+            json.dumps(cluster_status))
         logger.info('Finished executing {0} for {1} in {2}'.format(
             command, a_host['address'], cluster_name))
 
@@ -158,9 +158,12 @@ def clusterexec(cluster_name, command):
     cluster_status['finished_at'] = datetime.datetime.utcnow().isoformat()
     cluster_status['status'] = end_status
 
+    logger.debug('Cluster {0} final {1} status: {2}'.format(
+        cluster_name, command, cluster_status))
+
     cherrypy.engine.publish(
-        'store-set',
+        'store-save',
         '/commissaire/cluster/{0}/{1}'.format(cluster_name, command),
-        json.dumps(cluster_status))[0]
+        json.dumps(cluster_status))
 
     logger.info('Clusterexec stopping')


### PR DESCRIPTION
This appears to just be a typo.  Cluster restarts were failing with:
```
2016-04-05 11:59:20,053 - clusterexec - 15834 -  140454330877696 - DEBUG - Cluster mycluster status: {'status': 'in_process', 'finished_at': None, 'started_at': '2016-04-05T15:59:07.669868', 'in_process': [u'192.168.122.67'], 'restarted': []}
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "build/bdist.linux-x86_64/egg/commissaire/jobs/clusterexec.py", line 167, in clusterexec
    json.dumps(cluster_status))[0]
IndexError: list index out of range
```

I added the debug line to figure out what `cluster_status` was.  May as well keep it.