### PR TITLE
[merged] Bootstrap can now copy over the CA for etcd if provided.

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -84,8 +84,10 @@ commissaire_docker_registry_port              The docker registry port
 commissaire_etcd_scheme                       The etcd server scheme (http/https)
 commissaire_etcd_host                         The etcd host
 commissaire_etcd_port                         The etcd port
+commissaire_etcd_ca_path                      Path to the etcd certificate authority
 commissaire_etcd_client_cert_path             Path to the etcd client certificate
 commissaire_etcd_client_key_path              Path to the etcd client key
+commissaire_etcd_ca_path_local                Path to the local etcd certificate authority
 commissaire_etcd_client_cert_path_local       Path to the local etcd client certificate
 commissaire_etcd_client_key_path_local        Path to the local etcd client key
 commissaire_flannel_key                       The flannel configuration key

--- a/doc/examples/run_e2e_bdd_example.rst
+++ b/doc/examples/run_e2e_bdd_example.rst
@@ -5,6 +5,11 @@
    ...
 
 
+.. note::
+
+   you can pass ``-D server-args=""`` to append server arguments when starting the server from behave.
+
+
 You can also run the tests against any commissaire/etcd instance directly.
 
 .. warning::

--- a/features/environment.py
+++ b/features/environment.py
@@ -69,10 +69,19 @@ def before_all(context):
             server_port = random.randint(8500, 9000)
             context.SERVER = 'http://127.0.0.1:{0}'.format(server_port)
             # TODO: add kubernetes URL to options
-            context.SERVER_PROCESS = subprocess.Popen(
-                ['python', 'src/commissaire/script.py',
-                 '-e', context.ETCD, '-k', 'http://127.0.0.1:8080',
-                 '--listen-port', str(server_port)])
+            server_cli_args = [
+                'python', 'src/commissaire/script.py',
+                '-e', context.ETCD, '-k', 'http://127.0.0.1:8080',
+                '--listen-port', str(server_port)]
+
+            # Add any other server-args
+            extra_server_args = context.config.userdata.get(
+                'server-args', None)
+            if extra_server_args:
+                server_cli_args += extra_server_args.split(' ')
+
+            print("Running server: {0}".format(" ".join(server_cli_args)))
+            context.SERVER_PROCESS = subprocess.Popen(server_cli_args)
             time.sleep(3)
             context.SERVER_PROCESS.poll()
             # If the returncode is not set then etcd is running

--- a/src/commissaire/data/ansible/playbooks/bootstrap.yaml
+++ b/src/commissaire/data/ansible/playbooks/bootstrap.yaml
@@ -24,6 +24,11 @@
         dest: "{{ commissaire_etcd_client_key_path }}"
         src: "{{ commissaire_etcd_client_key_path_local }}"
       when: "{{ commissaire_etcd_use_cert }}"
+    - name: Add Etcd CA
+      copy:
+        dest: "{{ commissaire_etcd_ca_path }}"
+        src: "{{ commissaire_etcd_ca_path_local }}"
+      when: "commissaire_etcd_ca_path is defined"
     - name: Install Docker
       command: "{{ commissaire_install_docker }}"
     - name: Configure Docker

--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,4 +1,5 @@
 FLANNEL_ETCD="{{ commissaire_etcd_scheme }}://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
 {%- if commissaire_etcd_use_cert %}
-FLANNEL_OPTIONS="--remote-keyfile={{ commissaire_etcd_client_key_path }} --remote-certfile={{ commissaire_etcd_client_cert_path }}"{% endif %}
+FLANNEL_OPTIONS="-remote-keyfile={{ commissaire_etcd_client_key_path }} -remote-certfile={{ commissaire_etcd_client_cert_path }} -etcd-cafile={{ commissaire_etcd_ca_path }}"{% elif commissaire_etcd_ca_path %}
+FLANNEL_OPTIONS="-etcd-cafile={{ commissaire_etcd_ca_path }}"{% endif %}

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -42,6 +42,8 @@ class OSCmdBase:
     etcd_client_cert = '/etc/etcd/client.crt'
     #: Full path to the etcd client key
     etcd_client_key = '/etc/etcd/key.crt'
+    #: Full path to the etcd ca file
+    etcd_ca = '/etc/etcd/cacert.pem'
 
     #: Docker service name
     docker_service = 'docker'

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -139,6 +139,9 @@ def main():  # pragma: no cover
         '--etcd-cert-key-path', '-K', type=str, required=False,
         help='Full path to the client side certificate key.')
     parser.add_argument(
+        '--etcd-ca-path', '-A', type=str, required=False,
+        help='Full path to the CA file.')
+    parser.add_argument(
         '--kube-uri', '-k', type=str, required=True,
         help='Full URI for kubernetes EX: http://127.0.0.1:8080')
     parser.add_argument(
@@ -163,12 +166,15 @@ def main():  # pragma: no cover
         'protocol': config.etcd['uri'].scheme,
     }
 
-    # We need both args to use a client side cert for etcd
+    if args.etcd_ca_path:
+        config.etcd['certificate_ca_path'] = args.etcd_ca_path
+
+    # We need all args to use a client side cert for etcd
     if bool(args.etcd_cert_path) ^ bool(args.etcd_cert_key_path):
         parser.error(
-            'Both etcd-cert-path and etcd-cert-key-path must be provided to '
-            'use a client side certificate with etcd.')
-    elif args.etcd_cert_path:
+            'Both etcd-cert-path and etcd-cert-key-path must be '
+            'provided to use a client side certificate with etcd.')
+    elif bool(args.etcd_cert_path):
         if config.etcd['uri'].scheme != 'https':
             parser.error('An https URI is required when using '
                          'client side certificates.')

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -166,7 +166,7 @@ def main():  # pragma: no cover
         'protocol': config.etcd['uri'].scheme,
     }
 
-    if args.etcd_ca_path:
+    if bool(args.etcd_ca_path):
         config.etcd['certificate_ca_path'] = args.etcd_ca_path
 
     # We need all args to use a client side cert for etcd

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -359,6 +359,14 @@ class Transport:
             'commissaire_kubeproxy_service': oscmd.kubelet_proxy_service,
         }
 
+        # Provide the CA if etcd is being used over https
+        if (
+                config.etcd['uri'].scheme == 'https' and
+                config.etcd.get('certificate_ca_path', None)):
+            play_vars['commissaire_etcd_ca_path'] = oscmd.etcd_ca
+            play_vars['commissaire_etcd_ca_path_local'] = (
+                config.etcd['certificate_ca_path'])
+
         # Client Certificate additions
         if config.etcd.get('certificate_path', None):
             self.logger.info('Using etcd client certs')


### PR DESCRIPTION
This is primarily for Flannel which will refuse to connect to etcd over
TLS if it doesn't have the proper CA available.