### PR TITLE
[merged] bug: etcd.Client now times out after 2 seconds.

### DIFF
--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -161,6 +161,7 @@ def main():  # pragma: no cover
         parser.error(ex)
 
     store_kwargs = {
+        'read_timeout': 2,
         'host': config.etcd['uri'].hostname,
         'port': config.etcd['uri'].port,
         'protocol': config.etcd['uri'].scheme,
@@ -187,7 +188,7 @@ def main():  # pragma: no cover
 
     try:
         logging.config.dictConfig(
-            json.loads(ds.get('/commissaire/config/logger').value))
+            json.loads(ds.read('/commissaire/config/logger').value))
         logging.info('Using Etcd for logging configuration.')
     except etcd.EtcdKeyNotFound:
         found_logger_config = False


### PR DESCRIPTION
When the commissaire server starts it attempts to get some configuration
from etcd. If the etcd host/port hangs the server would hang. This adds
a 2 second timeout to the etcd.Client reads so that the server exits
on start up with a failure instead of hanging forver.

Closes #98.