### PR TITLE
[merged] authentication is now configurable via CLI switch.

### DIFF
--- a/doc/apidoc/commissaire.authentication.httpauthbyetcd.rst
+++ b/doc/apidoc/commissaire.authentication.httpauthbyetcd.rst
@@ -1,0 +1,7 @@
+commissaire.authentication.httpauthbyetcd module
+================================================
+
+.. automodule:: commissaire.authentication.httpauthbyetcd
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.authentication.httpauthbyfile.rst
+++ b/doc/apidoc/commissaire.authentication.httpauthbyfile.rst
@@ -1,0 +1,7 @@
+commissaire.authentication.httpauthbyfile module
+================================================
+
+.. automodule:: commissaire.authentication.httpauthbyfile
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.authentication.rst
+++ b/doc/apidoc/commissaire.authentication.rst
@@ -7,6 +7,8 @@ Submodules
 .. toctree::
 
    commissaire.authentication.httpauth
+   commissaire.authentication.httpauthbyetcd
+   commissaire.authentication.httpauthbyfile
 
 Module contents
 ---------------

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -1,6 +1,20 @@
 Authentication
 ==============
 
+Defining Authentication Plugin
+------------------------------
+
+The default authentication plugin uses a JSON schema in etcd to lookup users.
+To change to another plugin use the ``--authentication-plugin`` switch. If the
+plugin has required configuration options you may also need to use the
+``--authentication-plugin-kwargs``.
+
+.. code-block:: shell
+
+   $ commissaire [...] \
+   --authentication-plugin commissaire.authentication.httpauthbyfile
+   --authentication-plugin-kwargs "filepath=/path/to/users.json"
+
 
 Modifying Users
 ---------------
@@ -8,8 +22,8 @@ Modifying Users
 By default commissaire will look at Etcd for user/hash combinations under
 the ``/commissaire/config/httpbasicauthbyuserlist`` key.
 
-If the key does not exist the backup is to use local file authentication
-using the same JSON schema.
+commissaire can also use a local file for authentication using the same JSON
+schema.
 
 .. code-block:: javascript
 

--- a/doc/authentication_devel.rst
+++ b/doc/authentication_devel.rst
@@ -2,30 +2,34 @@ Authentication Plugins
 ======================
 
 commissaire's authentication is handled by a simple
-plugin based system. To create a new authentication plugin
-subclass ``commissaire.authentication.Authenticator``
-and implement the ``authenticate`` method. The ``authenticate``
-should always return on success or raise ``falcon.HTTPForbidden``
-on failure.
+plugin based system. To create a new authentication plugin you must:
+
+- subclass ``commissaire.authentication.Authenticator``
+- name the class ``AuthenticationPlugin``
+- override the ``authenticate`` method
+
+If you need to have configuration items passed when used you will also need to
+override ``__init__`` adding in keyword arguments.
 
 .. note::
-   In the future this will be configurable through a configuration file.
-   For now it requires code modification to switch out a plugin.
 
+   The ``authenticate`` should always return on success or raise
+   ``falcon.HTTPForbidden`` on failure.
+
+Once created it can be used via the ``--authentication-plugin`` and
+``--authentication-plugin-kwargs`` command line switches.
 
 Example
--------
+```````
 
-.. code-block:: python
+.. literalinclude:: ../src/commissaire/authentication/httpauth.py
 
-   import falcon
 
-   from commissaire.authentication import Authenticator
+Example With Config
+````````````````````
 
-   
-   class LocalhostOnlyAuthenticator(Authenticator):
+.. note::
 
-       def authenticate(self, req, resp):
-           if r.env['REMOTE_ADDR'] == '127.0.0.1':
-               return
-           raise falcon.HTTPForbidden()
+   This subclasses the first example.
+
+.. literalinclude:: ../src/commissaire/authentication/httpauthbyfile.py

--- a/doc/examples/run_from_source.rst
+++ b/doc/examples/run_from_source.rst
@@ -3,5 +3,7 @@
 
    (virtualenv)$ PYTHONPATH=`pwd`/src python src/commissaire/script.py \
        --etcd-uri http://127.0.0.1:2379 \
-       --kube-uri http://127.0.0.1:8080 &
+       --kube-uri http://127.0.0.1:8080 \
+       --authentication-plugin commissaire.authentication.httpauthbyfile \
+       --authentication-plugin-kwargs "filepath=conf/users.json" &
    ...

--- a/doc/examples/run_from_source_more_secure.rst
+++ b/doc/examples/run_from_source_more_secure.rst
@@ -10,5 +10,7 @@
        --tls-certificate /path/to/server.crt \
        --etcd-uri https://127.0.0.1:2379
        --etcd-cert-path /path/to/etcd_clientside.crt \
-       --etcd-cert-key-path /path/to/etcd_clientside.key &
+       --etcd-cert-key-path /path/to/etcd_clientside.key \
+       --authentication-plugin commissaire.authentication.httpauthbyfile \
+       --authentication-plugin-kwargs "filepath=conf/users.json" &
    ...

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -94,6 +94,11 @@ Via Docker
 ``````````
 To run the image specify the ETCD and KUBE variables pointing towards the specific services.
 
+.. note::
+
+   These commands assume you have put user configuration in etcd and are using
+   the ``commissaire.authentication.httpauthbyetcd`` authentication plugin.
+
 **Not So Secure Mode**
 
 .. include:: examples/run_via_docker.rst

--- a/src/commissaire/authentication/httpauthbyetcd.py
+++ b/src/commissaire/authentication/httpauthbyetcd.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import cherrypy
+import json
+
+from commissaire.authentication.httpauth import _HTTPBasicAuth
+
+
+class HTTPBasicAuthByEtcd(_HTTPBasicAuth):
+    """
+    HTTP Basic auth backed by Etcd JSON value.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the HTTPBasicAuthByEtcd authenticator.
+
+        :returns: HTTPBasicAuthByEtcd
+        """
+        self._data = {}
+        self.load()
+
+    def load(self):
+        """
+        Loads the authentication information from etcd.
+        """
+        d, error = cherrypy.engine.publish(
+            'store-get', '/commissaire/config/httpbasicauthbyuserlist')[0]
+
+        if error:
+            if type(error) == ValueError:
+                self.logger.warn(
+                    'User configuration in Etcd is not valid JSON. Raising...')
+            else:
+                self.logger.warn(
+                    'User configuration not found in Etcd. Raising...')
+            self._data = {}
+            raise error
+
+        self._data = json.loads(d.value)
+        self.logger.info('Loaded authentication data from Etcd.')
+
+
+AuthenticationPlugin = HTTPBasicAuthByEtcd

--- a/src/commissaire/authentication/httpauthbyfile.py
+++ b/src/commissaire/authentication/httpauthbyfile.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import json
+
+from commissaire.compat import exception
+from commissaire.authentication.httpauth import _HTTPBasicAuth
+
+
+class HTTPBasicAuthByFile(_HTTPBasicAuth):
+    """
+    HTTP Basic auth backed by a JSON file.
+    """
+
+    def __init__(self, filepath):
+        """
+        Creates an instance of the HTTPBasicAuthByFile authenticator.
+
+        :param filepath: The file path to the JSON file backing authentication.
+        :type filepath: string
+        :returns: HTTPBasicAuthByFile
+        """
+        self.filepath = filepath
+        self._data = {}
+        self.load()
+
+    def load(self):
+        """
+        Loads the authentication information from the JSON file.
+        """
+        try:
+            with open(self.filepath, 'r') as afile:
+                self._data = json.load(afile)
+                self.logger.info('Loaded authentication data from local file.')
+        except:
+            _, ve, _ = exception.raise_if_not((ValueError, IOError))
+            self.logger.warn(
+                'Denying all access due to problem parsing '
+                'JSON file: {0}'.format(ve))
+            self._data = {}
+
+
+AuthenticationPlugin = HTTPBasicAuthByFile

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -42,7 +42,7 @@ from commissaire.middleware import JSONify
 
 def create_app(
         store,
-        authentication_module_path,
+        authentication_module_name,
         authentication_kwargs,
         users_paths=('/etc/commissaire/users.json', './conf/users.json')):
     """
@@ -50,8 +50,8 @@ def create_app(
 
     :param store: The etcd client to for storing/retrieving data.
     :type store: etcd.Client
-    :param authentication_module_path: Path to the module.
-    :type authentication_module_path: str
+    :param authentication_module_name: Full name of the authentication module.
+    :type authentication_module_name: str
     :param authentication_kwargs: Keyword arguments to pass to the auth mod.
     :type authentication_kwargs: dict
     :returns: The commissaire application.
@@ -59,12 +59,12 @@ def create_app(
     """
     try:
         authentication_class = getattr(__import__(
-            authentication_module_path, fromlist=["True"]),
+            authentication_module_name, fromlist=["True"]),
             'AuthenticationPlugin')
         authentication = authentication_class(**authentication_kwargs)
     except ImportError:
         raise Exception('Can not import {0} for authentication'.format(
-            authentication_module_path))
+            authentication_module_name))
 
     app = falcon.API(middleware=[authentication, JSONify()])
 
@@ -293,7 +293,7 @@ def main():  # pragma: no cover
         if '=' in args.authentication_plugin_kwargs:
             for item in args.authentication_plugin_kwargs.split(','):
                 key, value = item.split('=')
-                authentication_kwargs[key] = value
+                authentication_kwargs[key.strip()] = value.strip()
         app = create_app(
             ds,
             args.authentication_plugin,

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -37,37 +37,36 @@ from commissaire.handlers.status import StatusResource
 from commissaire.queues import INVESTIGATE_QUEUE
 from commissaire.jobs import PROCS
 from commissaire.jobs.investigator import investigator
-from commissaire.authentication import httpauth
 from commissaire.middleware import JSONify
 
 
 def create_app(
         store,
+        authentication_module_path,
+        authentication_kwargs,
         users_paths=('/etc/commissaire/users.json', './conf/users.json')):
     """
     Creates a new WSGI compliant commissaire application.
 
     :param store: The etcd client to for storing/retrieving data.
     :type store: etcd.Client
-    :param users_paths: Path(s) to where the users.json can be found.
-    :type users_paths: str or iterable
+    :param authentication_module_path: Path to the module.
+    :type authentication_module_path: str
+    :param authentication_kwargs: Keyword arguments to pass to the auth mod.
+    :type authentication_kwargs: dict
     :returns: The commissaire application.
     :rtype: falcon.API
     """
     try:
-        http_auth = httpauth.HTTPBasicAuthByEtcd()
-    except etcd.EtcdKeyNotFound:
-        if not hasattr(users_paths, '__iter__'):
-            users_paths = [users_paths]
-        http_auth = None
-        for user_path in users_paths:
-            if os.path.isfile(user_path):
-                http_auth = httpauth.HTTPBasicAuthByFile(user_path)
-        if http_auth is None:
-            raise Exception('User configuration must be set in Etcd '
-                            'or on the file system ({0}).'.format(users_paths))
+        authentication_class = getattr(__import__(
+            authentication_module_path, fromlist=["True"]),
+            'AuthenticationPlugin')
+        authentication = authentication_class(**authentication_kwargs)
+    except ImportError:
+        raise Exception('Can not import {0} for authentication'.format(
+            authentication_module_path))
 
-    app = falcon.API(middleware=[http_auth, JSONify()])
+    app = falcon.API(middleware=[authentication, JSONify()])
 
     app.add_route('/api/v0/status', StatusResource(store, None))
     app.add_route('/api/v0/cluster/{name}', ClusterResource(store, None))
@@ -150,6 +149,15 @@ def main():  # pragma: no cover
     parser.add_argument(
         '--tls-certfile', type=str, required=False,
         help='Full path to the TLS certfile for the commissaire server')
+    parser.add_argument(
+        '--authentication-plugin', type=str, required=False,
+        default='commissaire.authentication.httpauthbyetcd',
+        help=('Authentication Plugin module. '
+              'EX: commissaire.authentication.httpauth'))
+    parser.add_argument(
+        '--authentication-plugin-kwargs', type=str,
+        required=False, default={},
+        help='Authentication Plugin configuration (key=value)')
 
     args = parser.parse_args()
 
@@ -279,11 +287,23 @@ def main():  # pragma: no cover
         target=investigator, args=(INVESTIGATE_QUEUE, config))
     PROCS['investigator'].start()
 
-    # Make and mount the app
-    app = create_app(ds)
-    cherrypy.tree.graft(app, "/")
-    # Server forever
-    cherrypy.engine.block()
+    try:
+        # Make and mount the app
+        authentication_kwargs = {}
+        if '=' in args.authentication_plugin_kwargs:
+            for item in args.authentication_plugin_kwargs.split(','):
+                key, value = item.split('=')
+                authentication_kwargs[key] = value
+        app = create_app(
+            ds,
+            args.authentication_plugin,
+            authentication_kwargs)
+        cherrypy.tree.graft(app, "/")
+
+        # Serve forever
+        cherrypy.engine.block()
+    except:
+        cherrypy.engine.stop()
 
     PROCS['investigator'].terminate()
     PROCS['investigator'].join()

--- a/test/test_authenticator_httpauth.py
+++ b/test/test_authenticator_httpauth.py
@@ -23,6 +23,8 @@ import mock
 from . import TestCase, get_fixture_file_path
 from falcon.testing.helpers import create_environ
 from commissaire.authentication import httpauth
+from commissaire.authentication import httpauthbyetcd
+from commissaire.authentication import httpauthbyfile
 
 
 class Test_HTTPBasicAuth(TestCase):
@@ -81,7 +83,7 @@ class TestHTTPBasicAuthByFile(TestCase):
         Sets up a fresh instance of the class before each run.
         """
         self.user_config = get_fixture_file_path('conf/users.json')
-        self.http_basic_auth_by_file = httpauth.HTTPBasicAuthByFile(
+        self.http_basic_auth_by_file = httpauthbyfile.HTTPBasicAuthByFile(
             self.user_config)
 
     def test_load_with_non_parsable_file(self):
@@ -100,7 +102,7 @@ class TestHTTPBasicAuthByFile(TestCase):
         """
         Verify authenticate works with a proper JSON file, Authorization header, and a matching user.
         """
-        self.http_basic_auth_by_file = httpauth.HTTPBasicAuthByFile(
+        self.http_basic_auth_by_file = httpauthbyfile.HTTPBasicAuthByFile(
             self.user_config)
         req = falcon.Request(
             create_environ(headers={'Authorization': 'basic YTph'}))
@@ -113,7 +115,7 @@ class TestHTTPBasicAuthByFile(TestCase):
         """
         Verify authenticate denies with a proper JSON file, Authorization header, and no matching user.
         """
-        self.http_basic_auth_by_file = httpauth.HTTPBasicAuthByFile(
+        self.http_basic_auth_by_file = httpauthbyfile.HTTPBasicAuthByFile(
             self.user_config)
         req = falcon.Request(
             create_environ(headers={'Authorization': 'basic Yjpi'}))
@@ -127,7 +129,7 @@ class TestHTTPBasicAuthByFile(TestCase):
         """
         Verify authenticate denies with a proper JSON file, Authorization header, and the wrong password.
         """
-        self.http_basic_auth_by_file = httpauth.HTTPBasicAuthByFile(
+        self.http_basic_auth_by_file = httpauthbyfile.HTTPBasicAuthByFile(
             self.user_config)
         req = falcon.Request(
             create_environ(headers={'Authorization': 'basic YTpiCg=='}))
@@ -158,7 +160,7 @@ class TestHTTPBasicAuthByEtcd(TestCase):
 
             self.assertRaises(
                 etcd.EtcdKeyNotFound,
-                httpauth.HTTPBasicAuthByEtcd)
+                httpauthbyetcd.HTTPBasicAuthByEtcd)
 
     def test_load_with_bad_data(self):
         """
@@ -169,7 +171,7 @@ class TestHTTPBasicAuthByEtcd(TestCase):
 
             self.assertRaises(
                 ValueError,
-                httpauth.HTTPBasicAuthByEtcd)
+                httpauthbyetcd.HTTPBasicAuthByEtcd)
 
     def test_authenticate_with_valid_user(self):
         """
@@ -184,7 +186,7 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             _publish.return_value = [[return_value, None]]
 
             # Reload with the data from the mock'd Etcd
-            http_basic_auth_by_etcd = httpauth.HTTPBasicAuthByEtcd()
+            http_basic_auth_by_etcd = httpauthbyetcd.HTTPBasicAuthByEtcd()
 
             # Test the call
             req = falcon.Request(
@@ -206,7 +208,7 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             _publish.return_value = [[return_value, None]]
 
             # Reload with the data from the mock'd Etcd
-            http_basic_auth_by_etcd = httpauth.HTTPBasicAuthByEtcd()
+            http_basic_auth_by_etcd = httpauthbyetcd.HTTPBasicAuthByEtcd()
 
             # Test the call
             req = falcon.Request(
@@ -228,7 +230,7 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             _publish.return_value = [[return_value, None]]
 
             # Reload with the data from the mock'd Etcd
-            http_basic_auth_by_etcd = httpauth.HTTPBasicAuthByEtcd()
+            http_basic_auth_by_etcd = httpauthbyetcd.HTTPBasicAuthByEtcd()
 
             req = falcon.Request(
                 create_environ(headers={'Authorization': 'basic YTpiCg=='}))

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -37,7 +37,9 @@ class Test_CreateApp(TestCase):
         with mock.patch('cherrypy.engine.publish') as _publish:
             _publish.return_value = [[[], etcd.EtcdKeyNotFound]]
             app = script.create_app(
-                None, os.path.realpath('../conf/users.json'))
+                None,
+                'commissaire.authentication.httpauthbyfile',
+                {'filepath': os.path.realpath('../conf/users.json')})
             self.assertTrue(isinstance(app, falcon.API))
             self.assertEquals(2, len(app._middleware))
 


### PR DESCRIPTION
The authentication systhem was designed to be pluggable. However, early
on we were hardcoding the plugins as a primary and backup. This adds the
ability to define a plugin to use as well as any configuration
parameters it may need. By default the
commissaire.authentication.httpauthbyetcd is used.