### PR TITLE
[merged] doc: remove references to hashpass

### DIFF
--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -22,13 +22,13 @@ using the same JSON schema.
 
 Generating a hash
 ~~~~~~~~~~~~~~~~~
-commissaire has a utility to create bcrypt hashes.
+commctl has a built-in command for creating bcrypt hashes.
 
 .. include:: examples/commctl_note.rst
 
 .. code-block:: shell
 
-	$ commissaire-hashpass
+	$ commctl create passhash
 	Password:
 	$2b$12$rq/RN.Y1WD0ZyKPpLJkFVOv3XdLxW5thJ3OEaRgaMMFCgzLzHjiJG
 	$

--- a/doc/examples/commctl_note.rst
+++ b/doc/examples/commctl_note.rst
@@ -1,4 +1,4 @@
 .. note::
 
-   **commctl** and **commissaire-hashpass** are part of the `commctl <https://github.com/projectatomic/commctl>`_ python package
+   **commctl** can be found in the `commctl <https://github.com/projectatomic/commctl>`_ python package
 


### PR DESCRIPTION
It's now part of the `commctl` CLI.
https://github.com/projectatomic/commctl/pull/4