### PR TITLE
[merged] Release Candidate 3

### DIFF
--- a/contrib/package/rpm/commissaire.spec
+++ b/contrib/package/rpm/commissaire.spec
@@ -20,8 +20,6 @@ BuildRequires:  python-nose
 BuildRequires:  python-flake8
 BuildRequires:  pkgconfig(systemd)
 
-# XXX: Waiting on python2-python-etcd to pass review
-#      https://bugzilla.redhat.com/show_bug.cgi?id=1310796
 Requires:  python-setuptools
 Requires:  python-cherrypy
 Requires:  python2-falcon

--- a/contrib/package/rpm/commissaire.spec
+++ b/contrib/package/rpm/commissaire.spec
@@ -1,6 +1,6 @@
 Name:           commissaire
-Version:        0.0.1rc2
-Release:        5%{?dist}
+Version:        0.0.1rc3
+Release:        1%{?dist}
 Summary:        Simple cluster host management
 License:        GPLv3+
 URL:            http://github.com/projectatomic/commissaire
@@ -86,6 +86,9 @@ install -D contrib/systemd/commissaire.service %{buildroot}%{_unitdir}/commissai
 
 
 %changelog
+* Tue Apr 19 2016 Matthew Barnes <mbarnes@redhat.com> - 0.0.1rc3-1
+- Update for RC3.
+
 * Mon Apr  4 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-5
 * commctl and commissaire-hash-pass are now their own package.
 

--- a/contrib/package/rpm/commissaire.spec
+++ b/contrib/package/rpm/commissaire.spec
@@ -76,7 +76,7 @@ install -D contrib/systemd/commissaire.service %{buildroot}%{_unitdir}/commissai
 %files
 %license COPYING
 %doc README.md
-%doc CONTRIUBUTORS
+%doc CONTRIBUTORS
 %doc MAINTAINERS
 %doc doc/apidoc/*.rst
 %{_bindir}/commissaire

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ test_require = extract_requirements('test-requirements.txt')
 
 setup(
     name='commissaire',
-    version='0.0.1rc2',
+    version='0.0.1rc3',
     description='Simple cluster host management',
     author=extract_names('CONTRIBUTORS'),
     maintainer=extract_names('MAINTAINERS'),

--- a/src/commissaire/__init__.py
+++ b/src/commissaire/__init__.py
@@ -16,4 +16,4 @@
 The commissaire package.
 """
 
-__version__ = '0.0.1rc2'
+__version__ = '0.0.1rc3'


### PR DESCRIPTION
I propose a 3rd release candidate before I submit Commissaire for Fedora package review.

I have to use an authoritative tarball for the review, and `rc2` is over a month old.  There's been several changes since then that affect packaging, especially the `commctl` split off.

Also, you might want to get the licensing change in first, unless that's getting delayed.