### PR TITLE
[merged] Better models

### DIFF
--- a/src/commissaire/cherrypy_plugins.py
+++ b/src/commissaire/cherrypy_plugins.py
@@ -57,6 +57,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         self.bus.log('Starting up Store access')
         self.bus.subscribe("store-save", self.store_save)
         self.bus.subscribe("store-get", self.store_get)
+        self.bus.subscribe("store-delete", self.store_delete)
 
     def stop(self):
         """
@@ -65,6 +66,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         self.bus.log('Stopping down Store access')
         self.bus.unsubscribe("store-save", self.store_save)
         self.bus.unsubscribe("store-get", self.store_get)
+        self.bus.unsubscribe("store-delete", self.store_delete)
 
     def store_save(self, key, json_entity, **kwargs):
         """
@@ -98,6 +100,22 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         try:
             store = self._get_store()
             return (store.get(key), None)
+        except:
+            _, exc, _ = sys.exc_info()
+            return ([], exc)
+
+    def store_delete(self, key):
+        """
+        Deletes json from the store.
+
+        :param key: The key to associate the data with.
+        :type key: str
+        :returns: The stores response and any errors that may have occured
+        :rtype: tuple(etcd.EtcdResult, Exception)
+        """
+        try:
+            store = self._get_store()
+            return (store.delete(key), None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)

--- a/src/commissaire/cherrypy_plugins.py
+++ b/src/commissaire/cherrypy_plugins.py
@@ -58,6 +58,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         self.bus.subscribe("store-save", self.store_save)
         self.bus.subscribe("store-get", self.store_get)
         self.bus.subscribe("store-delete", self.store_delete)
+        self.bus.subscribe("store-list", self.store_list)
 
     def stop(self):
         """
@@ -67,6 +68,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         self.bus.unsubscribe("store-save", self.store_save)
         self.bus.unsubscribe("store-get", self.store_get)
         self.bus.unsubscribe("store-delete", self.store_delete)
+        self.bus.unsubscribe("store-list", self.store_list)
 
     def store_save(self, key, json_entity, **kwargs):
         """
@@ -116,6 +118,22 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         try:
             store = self._get_store()
             return (store.delete(key), None)
+        except:
+            _, exc, _ = sys.exc_info()
+            return ([], exc)
+
+    def store_list(self, key):
+        """
+        Lists a directory.
+
+        :param key: The key to associate the data with.
+        :type key: str
+        :returns: The stores response and any errors that may have occured
+        :rtype: tuple(etcd.EtcdResult, Exception)
+        """
+        try:
+            store = self._get_store()
+            return (store.read(key, recursive=True), None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -68,8 +68,9 @@ def etcd_cluster_has_host(name, address):
     :param address: Host address
     :type address: str
     """
-    cluster = get_cluster_model(name)
-    if not cluster:
+    try:
+        cluster = Cluster.retrieve(name)
+    except:
         raise KeyError
 
     return address in cluster.hostset
@@ -88,8 +89,9 @@ def etcd_cluster_add_host(name, address):
     :param address: Host address to add
     :type address: str
     """
-    cluster = get_cluster_model(name)
-    if not cluster:
+    try:
+        cluster = Cluster.retrieve(name)
+    except:
         raise KeyError
 
     # FIXME: Need input validation.
@@ -103,12 +105,7 @@ def etcd_cluster_add_host(name, address):
 
     if address not in cluster.hostset:
         cluster.hostset.append(address)
-
-    etcd_resp, _ = cherrypy.engine.publish(
-        'store-save',
-        cluster.etcd.key,
-        cluster.to_json(secure=True),
-        prevValue=cluster.etcd.value)[0]
+        cluster.save(name)
 
 
 def etcd_cluster_remove_host(name, address):

--- a/src/commissaire/model.py
+++ b/src/commissaire/model.py
@@ -129,7 +129,8 @@ class Model:
         :rtype: model
         """
         key = self._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish('store-save', key)[0]
+        etcd_resp, error = cherrypy.engine.publish(
+            'store-save', key, self.to_json())[0]
         if error:
             raise Exception(error)
         return self

--- a/test/test_cherrypy_plugins.py
+++ b/test/test_cherrypy_plugins.py
@@ -28,7 +28,7 @@ class Test_CherryPyStorePlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('store-get', 'store-save', 'store-delete')
+    topics = ('store-get', 'store-save', 'store-delete', 'store-list')
 
     def before(self):
         """

--- a/test/test_cherrypy_plugins.py
+++ b/test/test_cherrypy_plugins.py
@@ -28,7 +28,7 @@ class Test_CherryPyStorePlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('store-get', 'store-save')
+    topics = ('store-get', 'store-save', 'store-delete')
 
     def before(self):
         """

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -97,9 +97,8 @@ class Test_HostsResource(TestCase):
         Verify listing Hosts.
         """
         with mock.patch('cherrypy.engine.publish') as _publish:
-            child = MagicMock(value=self.etcd_host)
-            self.return_value._children = [child]
-            self.return_value.leaves = self.return_value._children
+            child = MagicMock(etcd.EtcdResult, value=self.etcd_host)
+            self.return_value.children = [child]
             _publish.return_value = [[self.return_value, None]]
 
             body = self.simulate_request('/api/v0/hosts')


### PR DESCRIPTION
This change allows a new way to use our models while building upon the CherryPy Plugin. Models can now do CRUD operations on themselves.

This doesn't stop the use of using the CherryPy Plugin interface, but for much usage the new model syntax should hopefully be clearer and easier to use.

**Note**: ```util``` was partially ported over. Porting it totally will be done in a different PR and set of work related to refactoring that module.