### PR TITLE
[merged] doc: Updated to clarify "Container Manager".

### DIFF
--- a/doc/components.rst
+++ b/doc/components.rst
@@ -35,10 +35,10 @@ etcd
 etcd is used as the data store for commissaire. Any persistent data is kept
 within etcd as either traditional *key* = *value* pairs or as *key* = *JSON*. While
 any etcd instance will work it's recommended to use the same etcd cluster with
-kubernetes.
+Kubernetes.
 
 Container Manager
 ~~~~~~~~~~~~~~~~~
-Kubernetes or OpenShift can used as the container manager. commissaire utilizes
-kubernetes api to ensure that new host nodes register properly. From this point
-forward kubernetes is able to use the host node to schedule pods, etc...
+OpenShift or Kubernetes can used as the container manager. commissaire utilizes
+Kubernetes api to ensure that new host nodes register properly. From this point
+forward Kubernetes is able to use the host node to schedule pods, etc...

--- a/doc/components.rst
+++ b/doc/components.rst
@@ -37,8 +37,8 @@ within etcd as either traditional *key* = *value* pairs or as *key* = *JSON*. Wh
 any etcd instance will work it's recommended to use the same etcd cluster with
 kubernetes.
 
-kubernetes
-~~~~~~~~~~
-kubernetes is used as the container manager. commissaire utilizes kubernetes
-api to ensure that new host nodes register properly. From this point forward
-kubernetes is able to use the host node to schedule pods, etc...
+Container Manager
+~~~~~~~~~~~~~~~~~
+Kubernetes or OpenShift can used as the container manager. commissaire utilizes
+kubernetes api to ensure that new host nodes register properly. From this point
+forward kubernetes is able to use the host node to schedule pods, etc...

--- a/doc/components.rst
+++ b/doc/components.rst
@@ -39,6 +39,6 @@ Kubernetes.
 
 Container Manager
 ~~~~~~~~~~~~~~~~~
-OpenShift or Kubernetes can used as the container manager. commissaire utilizes
+OpenShift or Kubernetes can be used as the container manager. commissaire utilizes
 Kubernetes api to ensure that new host nodes register properly. From this point
 forward Kubernetes is able to use the host node to schedule pods, etc...

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -10,7 +10,7 @@ To test out the current code you will need the following installed:
 * Python2.6+
 * virtualenv
 * etcd2 (running)
-* Kubernetes or OpenShift Cluster (running)
+* OpenShift or Kubernetes Cluster (running)
 * (Optional) docker (running)
 
 Set up virtualenv

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -10,7 +10,7 @@ To test out the current code you will need the following installed:
 * Python2.6+
 * virtualenv
 * etcd2 (running)
-* Kubernetes Cluster with a bearer token for access (running)
+* Kubernetes or OpenShift Cluster (running)
 * (Optional) docker (running)
 
 Set up virtualenv
@@ -42,10 +42,10 @@ commissaire will default back to the local files but using Etcd is where configu
 .. include:: examples/etcd_logging_example.rst
 
 
-(Optional) Set The Kubernetes Access Method
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(Optional) Set The OpenShift or Kubernetes Access Method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two methods for accessing Kubernetes: Client Side Certificate and Bearer Token. Only one is needed when working with a secured Kubernetes installation.
+There are two methods for accessing the container manager: Client Side Certificate and Bearer Token. Only one is needed when working with a secured Kubernetes installation.
 
 (Recommended) Client Certificate
 ````````````````````````````````

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -7,7 +7,7 @@ Overview
 
    -- Ryan Cook
 
-commissaire is a lightweight REST interface for upgrading, restarting, and bootstrapping new hosts into an existing Container Management cluster such as Kubernetes or OpenShift.
+commissaire is a lightweight REST interface for upgrading, restarting, and bootstrapping new hosts into an existing Container Management cluster such as OpenShift or Kubernetes.
 
 Feature Overview
 ----------------

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -7,14 +7,14 @@ Overview
 
    -- Ryan Cook
 
-commissaire is a lightweight REST interface for upgrading, restarting, and bootstrapping new hosts into an existing Container Management cluster.
+commissaire is a lightweight REST interface for upgrading, restarting, and bootstrapping new hosts into an existing Container Management cluster such as Kubernetes or OpenShift.
 
 Feature Overview
 ----------------
 
-- Restart hosts in a container cluster
-- Upgrade hosts in a container cluster
-- Bootstrap new hosts into an existing container cluster
+- Restart hosts in an OpenShift or Kubernetes cluster
+- Upgrade hosts in a OpenShift or Kubernetes cluster
+- Bootstrap new hosts into an existing OpenShift or Kubernetes cluster
 - No agent required for hosts: All communication is done over SSH
 - Simple REST interface for automation
 - Service status for health checking
@@ -34,7 +34,7 @@ What commissaire Is Not
 There are a lot of overloaded words in technology. It's important to note what 
 commissaire is not as much as what it is. commissaire is not:
 
-- A Container Manager or scheduler (such as kubernetes)
+- A Container Manager or scheduler (such as OpenShift or Kubernetes)
 - A configuration management system (such as ansible or puppet)
 - A replacement for individual host management systems
 


### PR DESCRIPTION
Issue #120 noted that it was not clear if Commissaire works with
OpenShift or not. This change attempts to clarify that "Container
Manager" can be either Kubernetes or OpenShift.

Resolves #120.