### PR TITLE
[merged] compat: logging.config.dictConfig for < 2.7 added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ A lightweight REST interface for upgrading, restarting, and bootstrapping new ho
 Development: Getting Up And Running
 ===================================
 See [Getting Started](http://commissaire.readthedocs.org/en/latest/gettingstarted.html#development-manual)
+
+
+Python Versions
+===============
+Development is done mainly on Python 2.7 but 2.6 compatibility is attempted to make usage on older distributions possible.

--- a/src/commissaire/authentication/__init__.py
+++ b/src/commissaire/authentication/__init__.py
@@ -16,9 +16,9 @@
 Authentication related code for commissaire.
 """
 
-import logging
-
 import falcon
+
+from commissaire.compat.logger import logging
 
 
 class Authenticator:

--- a/src/commissaire/compat/__init__.py
+++ b/src/commissaire/compat/__init__.py
@@ -19,4 +19,7 @@ Python2/3 compat module.
 import platform
 
 #: Version of the current interpreter
-__python_version__ = platform.python_version()[0]
+__python_semver__ = platform.python_version().split('.')
+
+#: Major version of the current interpreter
+__python_version__ = __python_semver__[0]

--- a/src/commissaire/compat/logger.py
+++ b/src/commissaire/compat/logger.py
@@ -50,9 +50,7 @@ if __python_version__ == '2' and int(__python_semver__[1]) < 7:
             # Stream isn't an accepted kwarg
             kwargs.pop('stream', None)
 
-            level_name = 'NOTSET'
-            if kwargs.get('level'):
-                level_name = kwargs.pop('level')
+            level_name = kwargs.pop('level', 'NOTSET')
 
             # Get the handler class, create it with it's kwargs and set level
             cls = getattr(__import__(mod, fromlist=['True']), cls_name)

--- a/src/commissaire/compat/logger.py
+++ b/src/commissaire/compat/logger.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Logging compat
+"""
+
+import logging as logging
+from logging import config as _logging_config
+
+from commissaire.compat import __python_version__, __python_semver__
+
+
+if __python_version__ == '2' and int(__python_semver__[1]) < 7:
+
+    def dictConfig(config):
+        """
+        Compatability function for Python < 2.7.
+
+        :param config: The configuration dictionary
+        :type config: dict
+
+        .. warning::
+
+           Does not support the all dictConfiguration options.
+        """
+        if int(config['version']) != 1:
+            raise ValueError('Unsupported version: {0}'.format(
+                config['version']))
+
+        formatters = {}
+        handlers = {}
+        for name, kwargs in config['handlers'].items():
+            mod, cls_name = kwargs['class'].rsplit('.', 1)
+            del kwargs['class']  # class isn't an accepted kwarg
+
+            # Formatter isn't an accepted kwarg
+            formatter_name = kwargs.pop('formatter', None)
+            # Stream isn't an accepted kwarg
+            kwargs.pop('stream', None)
+
+            level_name = 'NOTSET'
+            if kwargs.get('level'):
+                level_name = kwargs.pop('level')
+
+            # Get the handler class, create it with it's kwargs and set level
+            cls = getattr(__import__(mod, fromlist=['True']), cls_name)
+            handlers[name] = cls(**kwargs)
+            handlers[name].setLevel(logging.getLevelName(level_name))
+            # Add a formatter if one was provided
+            if formatter_name:
+                formatters[formatter_name] = logging.Formatter(
+                    config['formatters'][formatter_name])
+                handlers[name].setFormatter(formatters[formatter_name])
+
+        # Merge the root logger into the loggers config
+        config['loggers'][''] = config['root']
+        # Configure the loggers
+        for logger_name, logger_kwargs in config['loggers'].items():
+            alogger = logging.getLogger(logger_name)
+            for handler_name in logger_kwargs['handlers']:
+                alogger.addHandler(handlers[handler_name])
+            alogger.setLevel(logging.getLevelName(logger_kwargs['level']))
+            alogger.propagate = logger_kwargs.get('propagate', True)
+
+    _logging_config.dictConfig = dictConfig
+
+logging.config = _logging_config

--- a/src/commissaire/config.py
+++ b/src/commissaire/config.py
@@ -16,9 +16,9 @@
 Configuration.
 """
 
-import logging
-
 import etcd
+
+from commissaire.compat.logger import logging
 
 
 class Config(dict):

--- a/src/commissaire/containermgr/__init__.py
+++ b/src/commissaire/containermgr/__init__.py
@@ -16,7 +16,7 @@
 The container manager package.
 """
 
-import logging
+from commissaire.compat.logger import logging
 
 
 class ContainerManagerBase(object):  # pragma: no cover

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -19,11 +19,11 @@ The clusterexec job.
 import cherrypy
 import datetime
 import json
-import logging
 import tempfile
 
 from commissaire.transport import ansibleapi
 from commissaire.compat.b64 import base64
+from commissaire.compat.logger import logging
 from commissaire.oscmd import get_oscmd
 
 

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -19,7 +19,6 @@ The investigator job.
 import cherrypy
 import datetime
 import json
-import logging
 import os
 import sys
 import tempfile
@@ -27,6 +26,7 @@ import tempfile
 from time import sleep
 
 from commissaire.compat.b64 import base64
+from commissaire.compat.logger import logging
 from commissaire.containermgr.kubernetes import KubeContainerManager
 from commissaire.oscmd import get_oscmd
 from commissaire.transport import ansibleapi

--- a/src/commissaire/resource.py
+++ b/src/commissaire/resource.py
@@ -16,7 +16,7 @@
 Basic Resource for commissaire.
 """
 
-import logging
+from commissaire.compat.logger import logging
 
 
 class Resource:

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -18,8 +18,6 @@
 import argparse
 import cherrypy
 import json
-import logging
-import logging.config
 import os
 import sys
 
@@ -28,6 +26,7 @@ import falcon
 
 from commissaire.compat.urlparser import urlparse
 from commissaire.compat import exception
+from commissaire.compat.logger import logging
 from commissaire.config import Config, cli_etcd_or_default
 from commissaire.handlers.clusters import (
     ClustersResource, ClusterResource,

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -16,8 +16,6 @@
 Ansible API transport.
 """
 
-import logging
-
 from collections import namedtuple
 from pkg_resources import resource_filename
 from time import sleep
@@ -29,6 +27,7 @@ from ansible.playbook.play import Play
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.plugins.callback import default
 from ansible.utils.display import Display
+from commissaire.compat.logger import logging
 
 
 class LogForward(default.CallbackModule):


### PR DESCRIPTION
We are using logging.config.dictConfig to allow easy configuration of our loggers via configuration files. However, this functionality was added in 2.7. This change adds a basic implementation of logging.config.dictConfig to allow configuration on 2.6. It is important to note that our reimplementation is not nearly as exhaustive as the true 2.7+ implementation.