### PR TITLE
[merged] doc: Updated commctl examples for updated syntax.

### DIFF
--- a/doc/examples/commctl_create_restart.rst
+++ b/doc/examples/commctl_create_restart.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl create restart datacenter1
+   commctl cluster restart start datacenter1
    ...

--- a/doc/examples/commctl_create_upgrade.rst
+++ b/doc/examples/commctl_create_upgrade.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl cluster upgrade start datacenter1 -u 7.2.2
+   commctl cluster upgrade start datacenter1 7.2.2
    ...

--- a/doc/examples/commctl_create_upgrade.rst
+++ b/doc/examples/commctl_create_upgrade.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl create upgrade datacenter1 -u 7.2.2
+   commctl cluster upgrade start datacenter1 -u 7.2.2
    ...

--- a/doc/examples/commctl_get_restart.rst
+++ b/doc/examples/commctl_get_restart.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl get restart datacenter1
+   commctl cluster restart status datacenter1
    ...

--- a/doc/examples/commctl_get_upgrade.rst
+++ b/doc/examples/commctl_get_upgrade.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl get upgrade datacenter1
+   commctl cluster upgrade status datacenter1
    ...

--- a/doc/examples/commctl_list_clusters.rst
+++ b/doc/examples/commctl_list_clusters.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl list clusters
+   commctl cluster list
    ...

--- a/doc/examples/commctl_list_hosts.rst
+++ b/doc/examples/commctl_list_hosts.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl list hosts
+   commctl host list
    ...

--- a/doc/examples/commctl_list_hosts_in_cluster.rst
+++ b/doc/examples/commctl_list_hosts_in_cluster.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   commctl list hosts -n datacenter1
+   commctl host list datacenter1
    ...


### PR DESCRIPTION
A recent change in commctl
(https://github.com/projectatomic/commctl/pull/12) inverted the CLI
syntax. This change updates the documentation to be inline with the new
CLI syntax.