### PR TITLE
[merged] Host object now house a remote ssh username.

### DIFF
--- a/contrib/cloud-init/commissaire.txt
+++ b/contrib/cloud-init/commissaire.txt
@@ -1,7 +1,9 @@
 {
   "endpoint": "https://master.example.com:8000",
-  "username": "user",                             # Optional
-  "password": "12345",                            # Optional
-  "cluster": "mycluster",                         # Optional
-  "root_ssh_key_path": "/root/.ssh/id_rsa"        # Optional
+  "username": "user",                                  # Optional
+  "password": "12345",                                 # Optional
+  "cluster": "mycluster",                              # Optional
+  "remote_user": "root",                               # Optional
+  "ssh_key_path": "/root/.ssh/id_rsa",                 # Optional
+  "authorized_keys_path": "/root/.ssh/authorized_keys" # Optional
 }

--- a/contrib/cloud-init/part-handler.py
+++ b/contrib/cloud-init/part-handler.py
@@ -65,7 +65,6 @@
 
 from __future__ import print_function
 
-import sys
 import stat
 import os
 import os.path
@@ -77,13 +76,26 @@ import json
 import requests
 
 MIME_TYPE = 'text/x-commissaire-host'
+handler_version = 2
 
 
 def list_types():
     return [MIME_TYPE]
 
 
-def handle_part(data, ctype, filename, payload):
+def run_cmd(cmd, desc, shell=False):
+    try:
+        print('Executing {}'.format(desc))
+        subprocess.check_call(cmd, shell=shell)
+    except FileNotFoundError:
+        print('Missing binary for command {}'.format(cmd))
+        raise
+    except subprocess.CalledProcessError as ex:
+        print('Error trying to {}: {}'.format(desc, str(ex)))
+        raise
+
+
+def handle_part(data, ctype, filename, payload, *args, **kwargs):
     if ctype == '__begin__':
         return
 
@@ -97,13 +109,11 @@ def handle_part(data, ctype, filename, payload):
         config = json.loads(payload)
         assert type(config) is dict
     except (AssertionError, ValueError):
-        print('{0}: {1} data must be a JSON object'.format(filename, ctype),
-              file=sys.stderr)
+        print('{0}: {1} data must be a JSON object'.format(filename, ctype))
         return
 
     if 'endpoint' not in config:
-        print('{0}: Missing required "endpoint" URI'.format(filename),
-              file=sys.stderr)
+        print('{0}: Missing required "endpoint" URI'.format(filename))
         return
 
     endpoint = config.get('endpoint')
@@ -117,23 +127,43 @@ def handle_part(data, ctype, filename, payload):
 
     # Verify the authorized_keys file exists
     if not os.path.isfile(authorized_keys):
+        print('Creating authorized_keys {}'.format(authorized_keys))
         authorized_keys_path, _ = authorized_keys.rsplit('/', 1)
         os.makedirs(authorized_keys_path)
         with open(authorized_keys, 'w', ) as _:
             pass
-        os.chmod(authorized_keys, 0600)
+        print('Chowning authorized_keys')
+        os.chmod(authorized_keys, 0o600)
+
+    if remote_user != 'root':
+        print('User is {}. Adding...'.format(remote_user))
+        run_cmd(
+            ['/sbin/useradd', remote_user],
+            'add user {}'.format(remote_user))
+        tmp_sudoers = '/tmp/{}'.format(remote_user)
+        run_cmd('/bin/echo "{}    ALL=NOPASSWD: ALL" > {}'.format(
+                remote_user, tmp_sudoers),
+                'create a suoders file for the {}'.format(remote_user),
+                shell=True)
+        run_cmd(
+            ['/bin/cp', tmp_sudoers,
+             '/etc/sudoers.d/{}'.format(remote_user)],
+            'add {} for sudoers'.format(remote_user))
 
     if not os.path.isfile(keyfile):
-        try:
-            subprocess.check_call(
-                ['/usr/bin/ssh-keygen', '-q', '-N', '',
-                 '-t', 'rsa', '-f', keyfile])
-        except FileNotFoundError:
-            print('Missing /usr/bin/ssh-keygen', file=sys.stderr)
-            raise
-        except subprocess.CalledProcessError as ex:
-            print(str(ex), file=sys.stderr)
-            raise
+        run_cmd(
+            ['/usr/bin/ssh-keygen', '-q', '-N', '',
+             '-t', 'rsa', '-f', keyfile],
+            'generate key file')
+        home_dir = os.path.expanduser('~' + remote_user)
+        print('home_dir is {}. Calling restorcon'.format(home_dir))
+        run_cmd(
+            ['/sbin/restorecon', '-R', '-v',
+             os.path.sep.join([home_dir, '.ssh'])],
+            'run restorcon on {}'.format(home_dir))
+        run_cmd(
+            ['/bin/chown', '-R', remote_user, home_dir],
+            'chown {} to {}'.format(home_dir, remote_user))
 
     try:
         with open(keyfile + '.pub') as inpf:
@@ -144,7 +174,7 @@ def handle_part(data, ctype, filename, payload):
             with os.fdopen(fd, 'a') as outf:
                 outf.writelines(inpf.readlines())
     except Exception as ex:
-        print(str(ex), file=sys.stderr)
+        print('Error writing key to authorized_keys: {}'.format(str(ex)))
         raise
 
     body = {
@@ -156,7 +186,7 @@ def handle_part(data, ctype, filename, payload):
             b64_bytes = base64.b64encode(f.read())
             body['ssh_priv_key'] = b64_bytes.decode()
     except Exception as ex:
-        print(str(ex), file=sys.stderr)
+        print(str(ex))
         raise
 
     if cluster:

--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -306,7 +306,8 @@ Creates a new host record.
 .. code-block:: javascript
 
    {
-       "ssh_priv_key": string // base64 encoded ssh private key
+       "ssh_priv_key": string, // base64 encoded ssh private key
+       "remote_user": string,  // Optional name of ssh user to use (default=root)
        "cluster": string      // Optional cluster the host should be associated with
    }
 
@@ -327,6 +328,7 @@ Example
 
    {
        "cluster": "default",
+       "remote_user": "root",
        "ssh_priv_key": "dGVzdAo..."
    }
 

--- a/doc/examples/create_host.rst
+++ b/doc/examples/create_host.rst
@@ -1,4 +1,4 @@
 .. code-block:: shell
 
-   curl -u "a:a" -XPUT -H "Content-Type: application/json" http://localhost:8000/api/v0/host/192.168.1.100 -d '{"host": "192.168.1.100", "cluster": "datacenter1", "ssh_priv_key": "dGVzdAo="}'
+   curl -u "a:a" -XPUT -H "Content-Type: application/json" http://localhost:8000/api/v0/host/192.168.1.100 -d '{"host": "192.168.1.100", "cluster": "datacenter1", "remote_user": "root", "ssh_priv_key": "dGVzdAo="}'
    ...

--- a/features/environment.py
+++ b/features/environment.py
@@ -204,6 +204,7 @@ def before_scenario(context, scenario):
     # Reset HOST_DATA
     context.HOST_DATA = {
         "address": "",
+        "remote_user": "root",
         "status": "active",
         "os": "fedora",
         "cpus": 1,

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -100,6 +100,8 @@ class HostResource(Resource):
             req_data = req.stream.read()
             req_body = json.loads(req_data.decode())
             ssh_priv_key = req_body['ssh_priv_key']
+            # Remote user is optional.
+            remote_user = req_body.get('remote_user', 'root')
             # Cluster member is optional.
             cluster_name = req_body.get('cluster', None)
         except (KeyError, ValueError):
@@ -110,7 +112,7 @@ class HostResource(Resource):
             return
 
         resp.status, host_model = util.etcd_host_create(
-            address, ssh_priv_key, cluster_name)
+            address, ssh_priv_key, remote_user, cluster_name)
 
         req.context['model'] = host_model
 
@@ -187,6 +189,8 @@ class ImplicitHostResource(Resource):
             req_data = req.stream.read()
             req_body = json.loads(req_data.decode())
             ssh_priv_key = req_body['ssh_priv_key']
+            # Remote user is optional.
+            remote_user = req_body.get('remote_user', 'root')
             # Cluster member is optional.
             cluster_name = req_body.get('cluster', None)
         except (KeyError, ValueError):
@@ -197,6 +201,6 @@ class ImplicitHostResource(Resource):
             return
 
         resp.status, host_model = util.etcd_host_create(
-            address, ssh_priv_key, cluster_name)
+            address, ssh_priv_key, remote_user, cluster_name)
 
         req.context['model'] = host_model

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -125,8 +125,8 @@ class Host(Model):
     _json_type = dict
     _attributes = (
         'address', 'status', 'os', 'cpus', 'memory',
-        'space', 'last_check', 'ssh_priv_key')
-    _hidden_attributes = ('ssh_priv_key', )
+        'space', 'last_check', 'ssh_priv_key', 'remote_user')
+    _hidden_attributes = ('ssh_priv_key', 'remote_user')
     _key = '/commissaire/hosts/{0}'
 
 

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -161,7 +161,7 @@ def get_cluster_model(name):
     return cluster
 
 
-def etcd_host_create(address, ssh_priv_key, cluster_name=None):
+def etcd_host_create(address, ssh_priv_key, remote_user, cluster_name=None):
     """
     Creates a new host record in etcd and optionally adds the host to
     the specified cluster.  Returns a (status, host) tuple where status
@@ -175,6 +175,8 @@ def etcd_host_create(address, ssh_priv_key, cluster_name=None):
     :type address: str
     :param ssh_priv_key: Host's SSH key, base64-encoded.
     :type ssh_priv_key: str
+    :param remote_user: The user to use with SSH.
+    :type remote_user: str
     :param cluster_name: Name of the cluster to join, or None
     :type cluster_name: str or None
     :return: (status, host)
@@ -207,7 +209,8 @@ def etcd_host_create(address, ssh_priv_key, cluster_name=None):
         'cpus': -1,
         'memory': -1,
         'space': -1,
-        'last_check': None
+        'last_check': None,
+        'remote_user': remote_user,
     }
 
     # Verify the cluster exists, if given.  Do it now
@@ -225,6 +228,6 @@ def etcd_host_create(address, ssh_priv_key, cluster_name=None):
     if cluster_name:
         etcd_cluster_add_host(cluster_name, address)
 
-    INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key))
+    INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key, remote_user))
 
     return (falcon.HTTP_201, Host(**json.loads(new_host.value)))

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -123,7 +123,7 @@ def clusterexec(cluster_name, command):
         f.close()
 
         try:
-            transport = ansibleapi.Transport()
+            transport = ansibleapi.Transport(a_host['remote_user'])
             exe = getattr(transport, command)
             result, facts = exe(
                 a_host['address'], key_file, oscmd)

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -65,12 +65,14 @@ def investigator(queue, config, run_once=False):
     while True:
         # Statuses follow:
         # http://commissaire.readthedocs.org/en/latest/enums.html#host-statuses
-        transport = ansibleapi.Transport()
-        to_investigate, ssh_priv_key = queue.get()
+        to_investigate, ssh_priv_key, remote_user = queue.get()
         address = to_investigate['address']
         logger.info('{0} is now in investigating.'.format(address))
-        logger.debug('Investigation details: key={0}, data={1}'.format(
-            to_investigate, ssh_priv_key))
+        logger.debug(
+            'Investigation details: key={0}, data={1}, remote_user={2}'.format(
+                to_investigate, ssh_priv_key, remote_user))
+
+        transport = ansibleapi.Transport(remote_user)
 
         f = tempfile.NamedTemporaryFile(prefix='key', delete=False)
         key_file = f.name

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -158,7 +158,8 @@ class Test_ClusterResource(TestCase):
                 '           "unavailable": 0}}')
 
     etcd_cluster = '{"status": "ok", "hostset": ["10.2.0.2"]}'
-    etcd_host = ('{"address": "10.2.0.2", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "10.2.0.2",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "active", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454",'

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -53,6 +53,7 @@ class Test_Hosts(TestCase):
         hosts_model = hosts.Hosts(
             hosts=[hosts.Host(
                 ssh_priv_key='dGVzdAo=',
+                remote_user='root',
                 address='127.0.0.1',
                 status='status',
                 os='atomic',
@@ -78,7 +79,8 @@ class Test_HostsResource(TestCase):
              ' "cpus": 2, "memory": 11989228, "space": 487652,'
              ' "last_check": "2015-12-17T15:48:18.710454"}')
 
-    etcd_host = ('{"address": "10.2.0.2", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "10.2.0.2",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "available", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454"}')
@@ -152,6 +154,7 @@ class Test_Host(TestCase):
         # Make sure a Host creates expected results
         host_model = hosts.Host(
             ssh_priv_key='dGVzdAo=',
+            remote_user='root',
             address='127.0.0.1',
             status='status',
             os='atomic',
@@ -173,7 +176,8 @@ class Test_HostResource(TestCase):
              ' "cpus": 2, "memory": 11989228, "space": 487652,'
              ' "last_check": "2015-12-17T15:48:18.710454"}')
 
-    etcd_host = ('{"address": "10.2.0.2", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "10.2.0.2",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "available", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454"}')
@@ -258,7 +262,7 @@ class Test_HostResource(TestCase):
                 [[MagicMock(value=self.etcd_host), None]],
                 [[MagicMock(value=self.etcd_cluster), None]],
                 [[MagicMock(value=self.etcd_cluster), None]])
-            data = ('{"ssh_priv_key": "dGVzdAo=",'
+            data = ('{"ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                     ' "cluster": "testing"}')
             body = self.simulate_request(
                 '/api/v0/host/10.2.0.2', method='PUT', body=data)
@@ -319,7 +323,8 @@ class Test_ImplicitHostResource(TestCase):
              ' "cpus": 2, "memory": 11989228, "space": 487652,'
              ' "last_check": "2015-12-17T15:48:18.710454"}')
 
-    etcd_host = ('{"address": "127.0.0.1", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "127.0.0.1",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "available", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454"}')
@@ -355,7 +360,7 @@ class Test_ImplicitHostResource(TestCase):
                 [[MagicMock(value=self.etcd_cluster), None]],
                 [[MagicMock(value=self.etcd_host), None]])
 
-            data = ('{"ssh_priv_key": "dGVzdAo=",'
+            data = ('{"ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                     ' "cluster": "testing"}')
             body = self.simulate_request(
                 '/api/v0/host', method='PUT', body=data)

--- a/test/test_jobs_clusterexec.py
+++ b/test/test_jobs_clusterexec.py
@@ -37,7 +37,8 @@ class Test_JobsClusterExec(TestCase):
     Tests for the clusterexec job.
     """
 
-    etcd_host = ('{"address": "10.2.0.2", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "10.2.0.2",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "available", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454", '

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -49,7 +49,8 @@ class Test_JobsInvestigator(TestCase):
     Tests for the investigator job.
     """
 
-    etcd_host = ('{"address": "10.2.0.2", "ssh_priv_key": "dGVzdAo=",'
+    etcd_host = ('{"address": "10.2.0.2",'
+                 ' "ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                  ' "status": "available", "os": "atomic",'
                  ' "cpus": 2, "memory": 11989228, "space": 487652,'
                  ' "last_check": "2015-12-17T15:48:18.710454"}')
@@ -91,7 +92,7 @@ class Test_JobsInvestigator(TestCase):
                 }
             }
 
-            q.put_nowait((to_investigate, ssh_priv_key))
+            q.put_nowait((to_investigate, ssh_priv_key, 'root'))
             investigator(q, connection_config, True)
 
             self.assertEquals(3, _publish.call_count)


### PR DESCRIPTION
This will allow OS's and cloud providers which block the use of root
ssh. If no ```remote_user``` is passed on host object creation root is used.
This change also introduces ```authorized_keys_file``` and ```remote_user``` to the
```cloud-init``` integration.