### PR TITLE
[merged] doc: Noting Python 2.7/3.1+ as a requirement.

### DIFF
--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -7,7 +7,7 @@ Manual Installation
 -------------------
 To test out the current code you will need the following installed:
 
-* Python2.6+
+* Python2.7 or Python3.1+
 * virtualenv
 * etcd2 (running)
 * OpenShift or Kubernetes Cluster (running)


### PR DESCRIPTION
I was hoping we could support 2.6 directly as well. However, 2.6 is not
supported by the community and dependencies either have or are dropping
support for unsupported versions. By upping to 2.7 or 3.1+ we can be
confident that the libraries we use will be compatible.