### PR TITLE
[merged] State etcd/kube switches are also used remotely.

### DIFF
--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -86,6 +86,12 @@ as specified by the ``--config-file`` option.
 
    Command-line options take precedence over the configuration file.
 
+.. note::
+
+   The URI you give for etcd and Kubernetes via the CLI will be fed into the
+   configuration files on remote host nodes. Make sure to use the public IP of
+   the etcd and Kubernetes hosts.
+
 From Source
 ```````````
 To launch the server from the repo root, with a configuration file such

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -198,7 +198,9 @@ def parse_args(parser):
         '--listen-port', '-p', type=int, help='Port to listen on')
     parser.add_argument(
         '--etcd-uri', '-e', type=str,
-        help='Full URI for etcd EX: http://127.0.0.1:2379')
+        help=('Full URI for etcd. This value is used for both local and remote'
+              ' host node connections to etcd.'
+              ' EX: http://192.168.152.100:2379'))
     parser.add_argument(
         '--etcd-cert-path', '-C', type=str,
         help='Full path to the client side certificate.')
@@ -210,7 +212,9 @@ def parse_args(parser):
         help='Full path to the CA file.')
     parser.add_argument(
         '--kube-uri', '-k', type=str,
-        help='Full URI for kubernetes EX: http://127.0.0.1:8080')
+        help=('Full URI for kubernetes. This value is used for both local and'
+              ' remote host node connection to kubernetes.'
+              ' EX: http://192.168.152.101:8080'))
     parser.add_argument(
         '--tls-keyfile', type=str,
         help='Full path to the TLS keyfile for the commissaire server')


### PR DESCRIPTION
This change notes the -e/-k switches specify the URI which is used
locally to connect to their respective services as well as being used on
the remote host nodes for accessing the services.