### PR TITLE
[merged] Add a "deploy" endpoint and remove arg from "upgrade"

### DIFF
--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -123,7 +123,6 @@ Retrieve the current status of upgrades.
 
    {
        "status": string,
-       "upgrade_to": string,
        "upgraded": HOST_LIST,
        "in_process": HOST_LIST,
        "started_at": string,
@@ -137,7 +136,6 @@ Example
 
    {
        "status": "in_process",
-       "upgrade_to": "7.2.1",
        "upgraded": [{...}],
        "in_process": [{...}],
        "started_at": "2015-12-17T15:48:18.710454",
@@ -148,20 +146,7 @@ PUT
 ```
 Start a new upgrade.
 
-.. code-block:: javascript
-
-   {
-       "upgrade_to": string
-   }
-
-Example
-~~~~~~~
-
-.. code-block:: javascript
-
-   {
-       "upgrade_to": "7.2.1"
-   }
+No body.
 
 Example Response
 ~~~~~~~~~~~~~~~~
@@ -170,7 +155,6 @@ Example Response
 
    {
        "status": "in_process",
-       "upgrade_to": "7.2.1",
        "upgraded": [{...}],
        "in_process": [{...}],
        "started_at": "2015-12-17T15:48:18.710454",

--- a/example/rest_calls.py
+++ b/example/rest_calls.py
@@ -297,19 +297,17 @@ expected_status(r, 200)
 
 print("=> Initiate Cluster Upgrade Without Auth (Should Fail)")
 r = requests.put(
-    SERVER + '/api/v0/cluster/honeynut/upgrade',
-    json={"upgrade_to": "7.2.1"})
+    SERVER + '/api/v0/cluster/honeynut/upgrade')
 print(r.json())
 expected_status(r, 403)
 
 print("=> Initiate Cluster Upgrade With Auth")
 r = requests.put(
-    SERVER + '/api/v0/cluster/honeynut/upgrade', auth=AUTH,
-    json={"upgrade_to": "7.2.1"})
+    SERVER + '/api/v0/cluster/honeynut/upgrade', auth=AUTH)
 actual = r.json()
 print(actual)
 del actual['started_at']  # Disregard timestamp
-expect = {'status': 'in_process', 'upgrade_to': '7.2.1', 'upgraded': [], 'in_process': [], 'finished_at': None}
+expect = {'status': 'in_process', 'upgraded': [], 'in_process': [], 'finished_at': None}
 expected_json(actual, expect) and expected_status(r, 201)
 
 print("=> Query Cluster Upgrade Status Without Auth (Should Fail)")

--- a/features/cluster/deploy.feature
+++ b/features/cluster/deploy.feature
@@ -1,0 +1,34 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@deploy
+@cluster
+Feature: Deploying Tree Image Across Clusters
+
+  @anonymous
+  Scenario: Initiate tree deployment without authentication
+     Given we are anonymous
+       and we have a cluster named honeynut
+      when we initiate a tree deployment of cluster honeynut
+      then commissaire will deny access
+
+  Scenario: Initiate tree deployment with authentication
+     Given we have a valid username and password
+       and we have a cluster named honeynut
+      when we initiate a tree deployment of cluster honeynut
+      then commissaire will allow access
+       and commissaire will note creation
+       and commissaire will provide deployment status
+       and the provided status is in_process

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -109,8 +109,7 @@ def impl(context, async_operation, cluster):
     if async_operation == 'an upgrade':
         context.request = requests.put(
             context.SERVER + '/api/v0/cluster/{0}/upgrade'.format(cluster),
-            auth=context.auth,
-            json={"upgrade_to": "7.2.1"})
+            auth=context.auth)
     elif async_operation == 'a restart':
         context.request = requests.put(
             context.SERVER + '/api/v0/cluster/{0}/restart'.format(cluster),
@@ -160,7 +159,7 @@ def impl(context, host, cluster):
 def impl(context, async_operation):
     json = context.request.json()
     if async_operation == 'upgrade':
-        expected_keys = set(('status', 'upgrade_to', 'upgraded',
+        expected_keys = set(('status', 'upgraded',
                              'in_process', 'started_at', 'finished_at'))
     elif async_operation == 'restart':
         expected_keys = set(('status', 'restarted', 'in_process',

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -114,6 +114,11 @@ def impl(context, async_operation, cluster):
         context.request = requests.put(
             context.SERVER + '/api/v0/cluster/{0}/restart'.format(cluster),
             auth=context.auth)
+    elif async_operation == 'a tree deployment':
+        context.request = requests.put(
+            context.SERVER + '/api/v0/cluster/{0}/deploy'.format(cluster),
+            auth=context.auth,
+            data=json.dumps({'version': '1.2.3'}))
     else:
         raise NotImplementedError
 
@@ -164,6 +169,9 @@ def impl(context, async_operation):
     elif async_operation == 'restart':
         expected_keys = set(('status', 'restarted', 'in_process',
                              'started_at', 'finished_at'))
+    elif async_operation == 'deployment':
+        expected_keys = set(('status', 'version', 'deployed',
+                             'in_process', 'started_at', 'finished_at'))
     actual_keys = set(json.keys())
     assert actual_keys == expected_keys, \
            'Expected keys {0}, got {1}'.format(expected_keys, actual_keys)

--- a/src/commissaire/data/ansible/playbooks/deploy.yaml
+++ b/src/commissaire/data/ansible/playbooks/deploy.yaml
@@ -12,26 +12,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Test cases for the commissaire.oscmd.fedora module.
-"""
+---
+- hosts: commissaire_targets
+  name: deploy
+  gather_facts: no
+  tasks:
+    - name: deploy tree image
+      command: "{{ commissaire_deploy_command }}"
 
-from . test_oscmd import _Test_OSCmd
-from commissaire.oscmd import fedora
-
-
-class Test_Fedora_OSCmd(_Test_OSCmd):
-    """
-    Tests for the OSCmd class for Fedora.
-    """
-
-    oscmdcls = fedora.OSCmd
-
-    def test_fedora_oscmd_commands(self):
-        """
-        Verify Fedora's OSCmd returns proper data on restart.
-        """
-        for meth, nargs in self.expected_methods:
-            args = tuple(range(nargs))
-            cmd = getattr(self.instance, meth)(*args)
-            self.assertEquals(list, type(cmd))

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -83,8 +83,7 @@ class ClusterUpgrade(Model):
     """
     _json_type = dict
     _attributes = (
-        'status', 'upgrade_to', 'upgraded', 'in_process',
-        'started_at', 'finished_at')
+        'status', 'upgraded', 'in_process', 'started_at', 'finished_at')
     _key = '/commissaire/cluster/{0}/upgrade'
 
 

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -66,6 +66,17 @@ class Cluster(Model):
         return self
 
 
+class ClusterDeploy(Model):
+    """
+    Representation of a Cluster deploy operation.
+    """
+    _json_type = dict
+    _attributes = (
+        'status', 'version', 'deployed', 'in_process',
+        'started_at', 'finished_at')
+    _key = '/commissaire/cluster/{0}/deploy'
+
+
 class ClusterRestart(Model):
     """
     Representation of a Cluster restart operation.

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -27,7 +27,7 @@ from commissaire.compat.logger import logging
 from commissaire.oscmd import get_oscmd
 
 
-def clusterexec(cluster_name, command):
+def clusterexec(cluster_name, command, kwargs={}):
     """
     Remote executes a shell commands across a cluster.
 
@@ -37,6 +37,7 @@ def clusterexec(cluster_name, command):
     logger = logging.getLogger('clusterexec')
 
     # TODO: This is a hack and should really be done elsewhere
+    command_args = ()
     if command == 'upgrade':
         finished_hosts_key = 'upgraded'
         cluster_status = {
@@ -101,7 +102,8 @@ def clusterexec(cluster_name, command):
             continue  # Move on to the next one
         oscmd = get_oscmd(a_host['os'])
 
-        command_list = getattr(oscmd, command)()  # Only used for logging
+        # command_list is only used for logging
+        command_list = getattr(oscmd, command)(*command_args)
         logger.info('Executing {0} on {1}...'.format(
             command_list, a_host['address']))
 
@@ -125,7 +127,7 @@ def clusterexec(cluster_name, command):
             transport = ansibleapi.Transport(a_host['remote_user'])
             exe = getattr(transport, command)
             result, facts = exe(
-                a_host['address'], key_file, oscmd)
+                a_host['address'], key_file, oscmd, kwargs)
         # XXX: ansibleapi explicitly raises Exception()
         except Exception:
             # If there was a failure set the end_status and break out

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -56,6 +56,18 @@ def clusterexec(cluster_name, command, kwargs={}):
             "started_at": datetime.datetime.utcnow().isoformat(),
             "finished_at": None
         }
+    elif command == 'deploy':
+        finished_hosts_key = 'deployed'
+        version = kwargs.get('version')
+        command_args = (version,)
+        cluster_status = {
+            "status": 'in_process',
+            "version": version,
+            "deployed": [],
+            "in_process": [],
+            "started_at": datetime.datetime.utcnow().isoformat(),
+            "finished_at": None
+        }
 
     end_status = 'finished'
 

--- a/src/commissaire/jobs/clusterexec.py
+++ b/src/commissaire/jobs/clusterexec.py
@@ -41,7 +41,6 @@ def clusterexec(cluster_name, command):
         finished_hosts_key = 'upgraded'
         cluster_status = {
             "status": 'in_process',
-            "upgrade_to": 'latest',
             "upgraded": [],
             "in_process": [],
             "started_at": datetime.datetime.utcnow().isoformat(),

--- a/src/commissaire/oscmd/__init__.py
+++ b/src/commissaire/oscmd/__init__.py
@@ -55,6 +55,19 @@ class OSCmdBase:
     kubelet_proxy_service = 'kube-proxy'
 
     @classmethod
+    def deploy(cls, version):
+        """
+        Deploy command. Must be overridden.
+
+        :param version: The tree image version to deploy
+        :type version: str
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        raise NotImplementedError(
+            '{0}.deploy() must be overridden.'.format(cls.__name__))
+
+    @classmethod
     def restart(cls):
         """
         Restart command. Must be overriden.

--- a/src/commissaire/oscmd/atomic.py
+++ b/src/commissaire/oscmd/atomic.py
@@ -37,6 +37,18 @@ class OSCmd(OSCmdBase):
     os_type = 'atomic'
 
     @classmethod
+    def deploy(cls, version):
+        """
+        Atomic deploy command.
+
+        :param version: The tree image version to deploy
+        :type version: str
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['rpm-ostree', 'deploy', version]
+
+    @classmethod
     def restart(cls):
         """
         Atomic restart command.

--- a/src/commissaire/oscmd/fedora.py
+++ b/src/commissaire/oscmd/fedora.py
@@ -28,6 +28,20 @@ class OSCmd(OSCmdBase):
     os_type = 'fedora'
 
     @classmethod
+    def deploy(cls, version):
+        """
+        Faux Fedora deploy command.
+
+        Deploy only works on atomic OS's.
+
+        :param version: The tree image version to deploy
+        :type version: str
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['true']
+
+    @classmethod
     def restart(cls):
         """
         Fedora restart command.

--- a/src/commissaire/oscmd/rhel.py
+++ b/src/commissaire/oscmd/rhel.py
@@ -28,6 +28,20 @@ class OSCmd(OSCmdBase):
     os_type = 'rhel'
 
     @classmethod
+    def deploy(cls, version):
+        """
+        Faux RHEL deploy command.
+
+        Deploy only works on atomic OS's.
+
+        :param version: The tree image version to deploy
+        :type version: str
+        :return: The command to execute as a list
+        :rtype: list
+        """
+        return ['true']
+
+    @classmethod
     def upgrade(cls):
         """
         RHEL upgrade command.

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -31,7 +31,8 @@ from commissaire.config import Config, cli_etcd_or_default
 from commissaire.handlers.clusters import (
     ClustersResource, ClusterResource,
     ClusterHostsResource, ClusterSingleHostResource,
-    ClusterRestartResource, ClusterUpgradeResource)
+    ClusterDeployResource, ClusterRestartResource,
+    ClusterUpgradeResource)
 from commissaire.handlers.hosts import (
     HostsResource, HostResource, ImplicitHostResource)
 from commissaire.handlers.status import StatusResource
@@ -77,6 +78,9 @@ def create_app(
     app.add_route(
         '/api/v0/cluster/{name}/hosts/{address}',
         ClusterSingleHostResource(store, None))
+    app.add_route(
+        '/api/v0/cluster/{name}/deploy',
+        ClusterDeployResource(store, None))
     app.add_route(
         '/api/v0/cluster/{name}/restart',
         ClusterRestartResource(store, None))

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -225,7 +225,7 @@ class Transport:
         self.logger.debug('{0}: Bad result {1}'.format(ip, result))
         raise Exception('Can not run for {0}'.format(ip))
 
-    def upgrade(self, ips, key_file, oscmd):
+    def upgrade(self, ips, key_file, oscmd, kwargs):
         """
         Upgrades a host via ansible.
 
@@ -235,15 +235,18 @@ class Transport:
         :type key_file: str
         :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
+        :param kwargs: keyword arguments for the remote command
+        :type kwargs: dict
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
         play_file = resource_filename(
             'commissaire', 'data/ansible/playbooks/upgrade.yaml')
+        upgrade_command = " ".join(oscmd.upgrade())
         return self._run(
             ips, key_file, play_file, [0],
-            {'commissaire_upgrade_command': " ".join(oscmd.upgrade())})
+            {'commissaire_upgrade_command': upgrade_command})
 
-    def restart(self, ips, key_file, oscmd):
+    def restart(self, ips, key_file, oscmd, kwargs):
         """
         Restarts a host via ansible.
 
@@ -253,13 +256,16 @@ class Transport:
         :type key_file: str
         :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
+        :param kwargs: keyword arguments for the remote command
+        :type kwargs: dict
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
         play_file = resource_filename(
             'commissaire', 'data/ansible/playbooks/restart.yaml')
+        restart_command = " ".join(oscmd.restart())
         return self._run(
             ips, key_file, play_file, [0, 2],
-            {'commissaire_restart_command': " ".join(oscmd.restart())})
+            {'commissaire_restart_command': restart_command})
 
     def get_info(self, ip, key_file):
         """

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -225,6 +225,27 @@ class Transport:
         self.logger.debug('{0}: Bad result {1}'.format(ip, result))
         raise Exception('Can not run for {0}'.format(ip))
 
+    def deploy(self, ips, key_file, oscmd, kwargs):
+        """
+        Deploys a tree image on a host via ansible.
+
+        :param ips: IP address(es) to upgrade.
+        :type ips: str or list
+        :param key_file: Full path to the file holding the private SSH key.
+        :type key_file: str
+        :param oscmd: OSCmd class to use
+        :type oscmd: commissaire.oscmd.OSCmdBase
+        :param kwargs: keyword arguments for the remote command
+        :type kwargs: dict
+        :returns: tuple -- (exitcode(int), facts(dict)).
+        """
+        play_file = resource_filename(
+            'commissaire', 'data/ansible/playbooks/deploy.yaml')
+        deploy_command = " ".join(oscmd.deploy(kwargs['version']))
+        return self._run(
+            ips, key_file, play_file, [0],
+            {'commissaire_deploy_command': deploy_command})
+
     def upgrade(self, ips, key_file, oscmd, kwargs):
         """
         Upgrades a host via ansible.

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -126,7 +126,7 @@ class Transport:
 
         :param ips: IP address(es) to check.
         :type ips: str or list
-        :param key_file: Full path the the file holding the private SSH key.
+        :param key_file: Full path to the file holding the private SSH key.
         :type key_file: string
         :param play_file: Path to the ansible play file.
         :type play_file: str
@@ -231,10 +231,10 @@ class Transport:
 
         :param ips: IP address(es) to upgrade.
         :type ips: str or list
-        :param key_file: Full path the the file holding the private SSH key.
+        :param key_file: Full path to the file holding the private SSH key.
+        :type key_file: str
         :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
-        :type key_file: str
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
         play_file = resource_filename(
@@ -249,7 +249,7 @@ class Transport:
 
         :param ips: IP address(es) to restart.
         :type ips: str or list
-        :param key_file: Full path the the file holding the private SSH key.
+        :param key_file: Full path to the file holding the private SSH key.
         :type key_file: str
         :param oscmd: OSCmd class to use
         :type oscmd: commissaire.oscmd.OSCmdBase
@@ -267,7 +267,7 @@ class Transport:
 
         :param ip: IP address to check.
         :type ip: str
-        :param key_file: Full path the the file holding the private SSH key.
+        :param key_file: Full path to the file holding the private SSH key.
         :type key_file: str
         :returns: tuple -- (exitcode(int), facts(dict)).
         """
@@ -312,7 +312,7 @@ class Transport:
 
         :param ip: IP address to reboot.
         :type ip: str
-        :param key_file: Full path the the file holding the private SSH key.
+        :param key_file: Full path to the file holding the private SSH key.
         :type key_file: str
         :param config: Configuration information.
         :type config: commissaire.config.Config

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -543,7 +543,7 @@ class Test_ClusterUpgrade(TestCase):
 
         # Make sure a Cluster Upgrade creates expected results
         cluster_upgrade_model = clusters.ClusterUpgrade(
-            status='in_process', upgrade_to='', upgraded=[], in_process=[],
+            status='in_process', upgraded=[], in_process=[],
             started_at=None, finished_at=None)
 
         self.assertEquals(type(str()), type(cluster_upgrade_model.to_json()))
@@ -554,7 +554,7 @@ class Test_ClusterUpgradeResource(TestCase):
     Tests for the ClusterUpgrade resource.
     """
 
-    aupgrade = ('{"status": "ok", "upgrade_to": "7.0.2", "upgraded": [],'
+    aupgrade = ('{"status": "ok", "upgraded": [],'
                 ' "in_process": [], "started_at": "",'
                 ' "finished_at": "0001-01-01T00:00:00"}')
 
@@ -613,23 +613,11 @@ class Test_ClusterUpgradeResource(TestCase):
                 [[[], etcd.EtcdKeyNotFound]],
                 [[MagicMock(etcd.EtcdResult, value=self.aupgrade), None]])
 
-            # Verify sending no/bad data returns a 400
-            for put_data in (None, '{"nothing": "here"}"'):
-                body = self.simulate_request(
-                    '/api/v0/cluster/development/upgrade',
-                    method='PUT',
-                    body=put_data)
-                self.assertEquals(falcon.HTTP_400, self.srmock.status)
-                self.assertEquals('{}', body[0])
-
             # Verify with creation
             body = self.simulate_request(
-                '/api/v0/cluster/development/upgrade',
-                method='PUT',
-                body='{"upgrade_to": "7.0.2"}')
+                '/api/v0/cluster/development/upgrade', method='PUT')
             self.assertEquals(falcon.HTTP_201, self.srmock.status)
             result = json.loads(body[0])
             self.assertEquals('in_process', result['status'])
-            self.assertEquals('7.0.2', result['upgrade_to'])
             self.assertEquals([], result['upgraded'])
             self.assertEquals([], result['in_process'])

--- a/test/test_jobs_clusterexec.py
+++ b/test/test_jobs_clusterexec.py
@@ -50,7 +50,7 @@ class Test_JobsClusterExec(TestCase):
         """
         Verify the clusterexec.
         """
-        for cmd in ('restart', 'upgrade'):
+        for cmd in ('deploy', 'restart', 'upgrade'):
             with contextlib.nested(
                     mock.patch('cherrypy.engine.publish'),
                     mock.patch('commissaire.transport.ansibleapi.Transport'),

--- a/test/test_oscmd.py
+++ b/test/test_oscmd.py
@@ -26,8 +26,14 @@ class _Test_OSCmd(TestCase):
     """
 
     oscmdcls = None
-    expected_methods = ('restart', 'upgrade', 'install_libselinux_python',
-                        'install_docker', 'install_flannel', 'install_kube')
+    # (method_name, nargs)
+    expected_methods = (('deploy', 1),
+                        ('restart', 0),
+                        ('upgrade', 0),
+                        ('install_libselinux_python', 0),
+                        ('install_docker', 0),
+                        ('install_flannel', 0),
+                        ('install_kube', 0))
 
     def before(self):
         """
@@ -47,10 +53,11 @@ class Test_OSCmdBase(_Test_OSCmd):
         """
         Verify OSCmdBase base methods all raises.
         """
-        for meth in self.expected_methods:
+        for meth, nargs in self.expected_methods:
             self.assertRaises(
                 NotImplementedError,
-                getattr(self.instance, meth))
+                getattr(self.instance, meth),
+                *tuple(range(nargs)))
 
 
 class Test_get_oscmd(TestCase):

--- a/test/test_oscmd_atomic.py
+++ b/test/test_oscmd_atomic.py
@@ -37,6 +37,7 @@ class Test_Atomic_OSCmd(_Test_OSCmd):
         """
         Verify Atomic's OSCmd returns proper data on restart.
         """
-        for meth in self.expected_methods:
-            cmd = getattr(self.instance, meth)()
+        for meth, nargs in self.expected_methods:
+            args = tuple(range(nargs))
+            cmd = getattr(self.instance, meth)(*args)
             self.assertEquals(list, type(cmd))

--- a/test/test_oscmd_redhat.py
+++ b/test/test_oscmd_redhat.py
@@ -31,6 +31,7 @@ class Test_Red_Hat_OSCmd(_Test_OSCmd):
         """
         Verify RHEL's OSCmd returns proper data on restart.
         """
-        for meth in self.expected_methods:
-            cmd = getattr(self.instance, meth)()
+        for meth, nargs in self.expected_methods:
+            args = tuple(range(nargs))
+            cmd = getattr(self.instance, meth)(*args)
             self.assertEquals(list, type(cmd))

--- a/test/test_oscmd_rhel.py
+++ b/test/test_oscmd_rhel.py
@@ -31,6 +31,7 @@ class Test_RHEL_OSCmd(_Test_OSCmd):
         """
         Verify RHEL's OSCmd returns proper data on restart.
         """
-        for meth in self.expected_methods:
-            cmd = getattr(self.instance, meth)()
+        for meth, nargs in self.expected_methods:
+            args = tuple(range(nargs))
+            cmd = getattr(self.instance, meth)(*args)
             self.assertEquals(list, type(cmd))


### PR DESCRIPTION
This PR does two things:

 1. Removes the version argument from `PUT /api/v0/cluster/{NAME}/upgrade` since none of the corresponding host commands actually take a version argument.  So upgrade always gets you to latest now.

 2. Introduces the endpoint `/api/v0/cluster/{NAME}/deploy` which *does* take a version argument.  The REST API works similar to `upgrade` and `restart`.  Behind the scenes this executes `rpm-ostree deploy VERSION` on an atomic OS, and has no effect on a traditional RPM-based OS.