### PR TITLE
[merged] Launch investigator from a CherryPy plugin.

### DIFF
--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -19,7 +19,6 @@ Status handlers.
 import cherrypy
 import falcon
 
-from commissaire.jobs import PROCS
 from commissaire.resource import Resource
 from commissaire.handlers.models import Status
 
@@ -64,7 +63,7 @@ class StatusResource(Resource):
 
         # Check investigator proccess
         # XXX: Change investigator if more than 1 process is allowed
-        if PROCS['investigator'].is_alive():
+        if cherrypy.engine.publish('investigator-is-alive')[0]:
             kwargs['investigator']['status'] = 'OK'
             kwargs['investigator']['info']['size'] = 1
             kwargs['investigator']['info']['in_use'] = 1

--- a/src/commissaire/jobs/__init__.py
+++ b/src/commissaire/jobs/__init__.py
@@ -13,10 +13,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-Storage for processes.
+Run targets for Process objects.
 """
-
-#: All multiprocessing processes
-PROCS = {
-    'investigator': None,
-}

--- a/test/test_handlers_status.py
+++ b/test/test_handlers_status.py
@@ -26,7 +26,6 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import status
 from commissaire.middleware import JSONify
-from commissaire.jobs import PROCS
 
 
 class Test_Status(TestCase):
@@ -75,12 +74,6 @@ class Test_StatusResource(TestCase):
             self.return_value._children = [child]
             self.return_value.leaves = self.return_value._children
             _publish.return_value = [[self.return_value, None]]
-
-            for proc in ('investigator', ):
-                PROCS[proc] = MagicMock(
-                    'multiprocessing.Process',
-                    is_alive=MagicMock(return_value=True),
-                )
 
             body = self.simulate_request('/api/v0/status')
             self.assertEqual(self.srmock.status, falcon.HTTP_200)

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -58,9 +58,9 @@ class Test_JobsInvestigator(TestCase):
         """
         Verify the investigator.
         """
-        with mock.patch('cherrypy.engine.publish') as _publish, \
-             mock.patch('commissaire.transport.ansibleapi.Transport') as _tp, \
-             mock.patch('etcd.Client') as _store:
+        with mock.patch('commissaire.transport.ansibleapi.Transport') as _tp, \
+             mock.patch('etcd.Client.get') as _etcd_get, \
+             mock.patch('etcd.Client.write') as _etcd_write:
 
             _tp().get_info.return_value = (
                 0,
@@ -73,8 +73,9 @@ class Test_JobsInvestigator(TestCase):
             )
 
             q = Queue()
-            _publish.return_value = [[
-                MagicMock('etcd.EtcdResult', value=self.etcd_host), None]]
+
+            _etcd_get.return_value = MagicMock(
+                'etcd.EtcdResult', value=self.etcd_host)
 
             to_investigate = {
                 'address': '10.0.0.2',
@@ -92,6 +93,7 @@ class Test_JobsInvestigator(TestCase):
             }
 
             q.put_nowait((to_investigate, ssh_priv_key, 'root'))
-            investigator(q, connection_config, True)
+            investigator(q, connection_config, run_once=True)
 
-            self.assertEquals(3, _publish.call_count)
+            self.assertEquals(1, _etcd_get.call_count)
+            self.assertEquals(2, _etcd_write.call_count)


### PR DESCRIPTION
I noticed the investigator process was leaking in the BDD tests.  This was because the BDD framework was sending the server process a SIGTERM, which terminated the main process immediately and left the investigator child process running.

CherryPy has a signal handler plugin, so I tried enabling it.

That's when things got weird.

I suspect something about the way `multiprocessing.Process` is implemented was causing `cherrypy.engine.exit()` to hang while waiting for child threads to terminate on SIGTERM.

So I had the idea of launching the investigator process from a CherryPy plugin to ensure it gets terminated.

Hence, `CherryPyInvestigatorPlugin`.

The other significant change is I gave the investigator its own `etcd.Client` instance.  Since this runs in a subprocess, **I don't understand how it was interacting with CherryPy plugins before**.  But however that worked my changes broke it, so I reverted back to direct `etcd.Client` calls.

Tests all pass and the child processes now get cleaned up properly.  What do you think?