### PR TITLE
[merged] Remove unused Resource members.

### DIFF
--- a/src/commissaire/resource.py
+++ b/src/commissaire/resource.py
@@ -24,19 +24,13 @@ class Resource:
     Parent class for all commissaire Resources.
     """
 
-    def __init__(self, store, queue=None, **kwargs):
+    def __init__(self, **kwargs):
         """
         Creates a new Resource instance.
 
-        :param store: The etcd client to for storing/retrieving data.
-        :type store: etcd.Client
-        :param queue: Optional queue to use with the Resource instance.
-        :type queue: gevent.queue.Queue
         :param kwargs: All other keyword arguemtns.
         :type kwargs: dict
         :returns: A new Resource instance.
         :rtype: commissaire.resource.Resource
         """
-        self.store = store
-        self.queue = queue
         self.logger = logging.getLogger('resources')

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -42,14 +42,11 @@ from commissaire.ssl_adapter import ClientCertBuiltinSSLAdapter
 
 
 def create_app(
-        store,
         authentication_module_name,
         authentication_kwargs):
     """
     Creates a new WSGI compliant commissaire application.
 
-    :param store: The etcd client to for storing/retrieving data.
-    :type store: etcd.Client
     :param authentication_module_name: Full name of the authentication module.
     :type authentication_module_name: str
     :param authentication_kwargs: Keyword arguments to pass to the auth mod.
@@ -68,27 +65,27 @@ def create_app(
 
     app = falcon.API(middleware=[authentication, JSONify()])
 
-    app.add_route('/api/v0/status', StatusResource(store, None))
-    app.add_route('/api/v0/cluster/{name}', ClusterResource(store, None))
+    app.add_route('/api/v0/status', StatusResource())
+    app.add_route('/api/v0/cluster/{name}', ClusterResource())
     app.add_route(
         '/api/v0/cluster/{name}/hosts',
-        ClusterHostsResource(store, None))
+        ClusterHostsResource())
     app.add_route(
         '/api/v0/cluster/{name}/hosts/{address}',
-        ClusterSingleHostResource(store, None))
+        ClusterSingleHostResource())
     app.add_route(
         '/api/v0/cluster/{name}/deploy',
-        ClusterDeployResource(store, None))
+        ClusterDeployResource())
     app.add_route(
         '/api/v0/cluster/{name}/restart',
-        ClusterRestartResource(store, None))
+        ClusterRestartResource())
     app.add_route(
         '/api/v0/cluster/{name}/upgrade',
-        ClusterUpgradeResource(store, None))
-    app.add_route('/api/v0/clusters', ClustersResource(store, None))
-    app.add_route('/api/v0/host', ImplicitHostResource(store, None))
-    app.add_route('/api/v0/host/{address}', HostResource(store, None))
-    app.add_route('/api/v0/hosts', HostsResource(store, None))
+        ClusterUpgradeResource())
+    app.add_route('/api/v0/clusters', ClustersResource())
+    app.add_route('/api/v0/host', ImplicitHostResource())
+    app.add_route('/api/v0/host/{address}', HostResource())
+    app.add_route('/api/v0/hosts', HostsResource())
     return app
 
 
@@ -428,7 +425,6 @@ def main():  # pragma: no cover
             authentication_kwargs = args.authentication_plugin_kwargs
 
         app = create_app(
-            ds,
             args.authentication_plugin,
             authentication_kwargs)
         cherrypy.tree.graft(app, "/")

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -70,11 +70,7 @@ class Test_ClustersResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = etcd.Client()
-        self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.resource = clusters.ClustersResource(self.datasource)
+        self.resource = clusters.ClustersResource()
         self.api.add_route('/api/v0/clusters', self.resource)
 
     def test_clusters_listing(self):
@@ -166,15 +162,7 @@ class Test_ClusterResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = MagicMock(etcd.Client)
-        self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.datasource.set = MagicMock(name='set')
-        self.datasource.set.return_value = self.return_value
-        self.datasource.delete = MagicMock(name='delete')
-        self.datasource.delete.return_value = self.return_value
-        self.resource = clusters.ClusterResource(self.datasource)
+        self.resource = clusters.ClusterResource()
         self.api.add_route('/api/v0/cluster/{name}', self.resource)
 
     def test_cluster_retrieve(self):
@@ -289,10 +277,7 @@ class Test_ClusterRestartResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = MagicMock(etcd.Client)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.set = MagicMock(name='set')
-        self.resource = clusters.ClusterRestartResource(self.datasource)
+        self.resource = clusters.ClusterRestartResource()
         self.api.add_route('/api/v0/cluster/{name}/restart', self.resource)
 
     def test_cluster_restart_retrieve(self):
@@ -351,13 +336,7 @@ class Test_ClusterHostsResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = MagicMock(etcd.Client)
-        self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.datasource.set = MagicMock(name='set')
-        self.datasource.set.return_value = self.return_value
-        self.resource = clusters.ClusterHostsResource(self.datasource)
+        self.resource = clusters.ClusterHostsResource()
         self.api.add_route('/api/v0/cluster/{name}/hosts', self.resource)
 
     def test_cluster_hosts_retrieve(self):
@@ -389,8 +368,6 @@ class Test_ClusterHostsResource(TestCase):
             # Verify setting host list works with a proper request
             _publish.return_value = [[MagicMock(
                 value=self.etcd_cluster), None]]
-            # self.datasource.get.return_value = MagicMock(
-            #    value=self.etcd_cluster)
             body = self.simulate_request(
                 '/api/v0/cluster/development/hosts', method='PUT',
                 body='{"old": ["10.2.0.2"], "new": ["10.2.0.2", "10.2.0.3"]}')
@@ -442,15 +419,7 @@ class Test_ClusterSingleHostResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = MagicMock(etcd.Client)
-        self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.datasource.set = MagicMock(name='set')
-        self.datasource.set.return_value = self.return_value
-        self.datasource.write = MagicMock(name='set')
-        self.datasource.write.return_value = self.return_value
-        self.resource = clusters.ClusterSingleHostResource(self.datasource)
+        self.resource = clusters.ClusterSingleHostResource()
         self.api.add_route(
             '/api/v0/cluster/{name}/hosts/{address}', self.resource)
 
@@ -559,10 +528,7 @@ class Test_ClusterUpgradeResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = MagicMock(etcd.Client)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.set = MagicMock(name='set')
-        self.resource = clusters.ClusterUpgradeResource(self.datasource)
+        self.resource = clusters.ClusterUpgradeResource()
         self.api.add_route('/api/v0/cluster/{name}/upgrade', self.resource)
 
     def test_cluster_upgrade_retrieve(self):
@@ -571,8 +537,6 @@ class Test_ClusterUpgradeResource(TestCase):
         """
         with mock.patch('cherrypy.engine.publish') as _publish:
             # Verify if the cluster upgrade exists the data is returned
-            self.datasource.get.return_value = MagicMock(
-                'etcd.EtcdResult', value=self.etcd_cluster)
             _publish.return_value = [[MagicMock(value=self.aupgrade), None]]
             body = self.simulate_request('/api/v0/cluster/development/upgrade')
             self.assertEqual(falcon.HTTP_200, self.srmock.status)
@@ -599,10 +563,6 @@ class Test_ClusterUpgradeResource(TestCase):
         with mock.patch('cherrypy.engine.publish') as _publish, \
              mock.patch('etcd.Client'), \
              mock.patch('commissaire.handlers.clusters.Process'):
-
-            self.datasource.get.side_effect = (
-                MagicMock(value=self.etcd_cluster),
-                etcd.EtcdKeyNotFound)
 
             _publish.side_effect = (
                 [[MagicMock(value=self.etcd_cluster), None]],

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -87,11 +87,8 @@ class Test_HostsResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware = [JSONify()])
-        self.datasource = etcd.Client()
         self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.resource = hosts.HostsResource(self.datasource)
+        self.resource = hosts.HostsResource()
         self.api.add_route('/api/v0/hosts', self.resource)
 
     def test_hosts_listing(self):
@@ -188,17 +185,8 @@ class Test_HostResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware = [JSONify()])
-        self.datasource = etcd.Client()
         self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.datasource.delete = MagicMock(name='delete')
-        self.datasource.delete.return_value = self.return_value
-        self.datasource.set = MagicMock(name='set')
-        self.datasource.set.return_value = self.return_value
-        self.datasource.write = MagicMock(name='set')
-        self.datasource.write.return_value = self.return_value
-        self.resource = hosts.HostResource(self.datasource)
+        self.resource = hosts.HostResource()
         self.api.add_route('/api/v0/host/{address}', self.resource)
 
     def test_host_retrieve(self):
@@ -335,17 +323,8 @@ class Test_ImplicitHostResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware = [JSONify()])
-        self.datasource = etcd.Client()
         self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.datasource.delete = MagicMock(name='delete')
-        self.datasource.delete.return_value = self.return_value
-        self.datasource.set = MagicMock(name='set')
-        self.datasource.set.return_value = self.return_value
-        self.datasource.write = MagicMock(name='set')
-        self.datasource.write.return_value = self.return_value
-        self.resource = hosts.ImplicitHostResource(self.datasource)
+        self.resource = hosts.ImplicitHostResource()
         self.api.add_route('/api/v0/host', self.resource)
 
     def test_implicit_host_create(self):

--- a/test/test_handlers_status.py
+++ b/test/test_handlers_status.py
@@ -58,11 +58,8 @@ class Test_StatusResource(TestCase):
 
     def before(self):
         self.api = falcon.API(middleware=[JSONify()])
-        self.datasource = etcd.Client()
         self.return_value = MagicMock(etcd.EtcdResult)
-        self.datasource.get = MagicMock(name='get')
-        self.datasource.get.return_value = self.return_value
-        self.resource = status.StatusResource(self.datasource)
+        self.resource = status.StatusResource()
         self.api.add_route('/api/v0/status', self.resource)
 
     def test_status_retrieve(self):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -41,7 +41,6 @@ class Test_CreateApp(TestCase):
         with mock.patch('cherrypy.engine.publish') as _publish:
             _publish.return_value = [[[], etcd.EtcdKeyNotFound]]
             app = script.create_app(
-                None,
                 'commissaire.authentication.httpbasicauth',
                 {'filepath': os.path.realpath('../conf/users.json')})
             self.assertTrue(isinstance(app, falcon.API))


### PR DESCRIPTION
Starting to prototype https://github.com/projectatomic/commissaire/wiki/cpd-126 with the refinements discussed in https://github.com/projectatomic/commissaire/issues/126, and I quickly ran into some leftover cruft from before the move to CherryPy.

A resource's `store` and `queue` members are no longer used.