### PR TITLE
[merged] cherrypy_plugins is now its own package.

### DIFF
--- a/src/commissaire/cherrypy_plugins/__init__.py
+++ b/src/commissaire/cherrypy_plugins/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Custom CherryPy plugins for commissaire.
+"""

--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Investigator plugin which allows control of investigators via the wsbus.
+"""
+
+from cherrypy.process import plugins
+
+from multiprocessing import Process
+from commissaire.queues import INVESTIGATE_QUEUE
+from commissaire.jobs.investigator import investigator
+
+
+class InvestigatorPlugin(plugins.SimplePlugin):
+
+    def __init__(self, bus, config, store_kwargs):
+        """
+        Creates a new instance of the InvestigatorPlugin.
+
+        :param bus: The CherryPy bus.
+        :type bus: cherrypy.process.wspbus.Bus
+        :param config: Configuration information.
+        :type config: commissaire.config.Config
+        :param store_kwargs: Keyword arguments used to make the etcd client.
+        :type store_kwargs: dict
+        """
+        plugins.SimplePlugin.__init__(self, bus)
+        self.process = Process(
+            target=investigator,
+            args=(INVESTIGATE_QUEUE, config, store_kwargs))
+        self.process.daemon = True
+        # TODO: Move to start()
+        self.bus.subscribe('investigator-is-alive', self.is_alive)
+
+    def start(self):
+        """
+        Starts the plugin and the investigator process.
+        """
+        self.bus.log('Starting up Investigator plugin')
+        self.process.start()
+
+    def stop(self):
+        """
+        Stops the plugin.
+        """
+        self.bus.log('Stopping down Investigator plugin')
+        self.bus.unsubscribe('investigator-is-alive', self.is_alive)
+        if self.is_alive():
+            self.process.terminate()
+            self.process.join()
+
+    def is_alive(self):
+        """
+        Returns whether the investigator process object is alive.
+
+        The investigator process object is alive from the moment the
+        start() method returns until the child process terminates.
+
+        :returns: Whether the investigator is alive
+        :rtype: bool
+        """
+        return self.process.is_alive()
+
+
+#: Generic name for the plugin
+Plugin = InvestigatorPlugin

--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -57,9 +57,6 @@ class InvestigatorPlugin(plugins.SimplePlugin):
         """
         self.bus.log('Stopping down Investigator plugin')
         self.bus.unsubscribe('investigator-is-alive', self.is_alive)
-        if self.is_alive():
-            self.process.terminate()
-            self.process.join()
 
     def is_alive(self):
         """

--- a/src/commissaire/cherrypy_plugins/store.py
+++ b/src/commissaire/cherrypy_plugins/store.py
@@ -22,51 +22,8 @@ import etcd
 
 from cherrypy.process import plugins
 
-from multiprocessing import Process
-from commissaire.queues import INVESTIGATE_QUEUE
-from commissaire.jobs.investigator import investigator
 
-
-class CherryPyInvestigatorPlugin(plugins.SimplePlugin):
-
-    def __init__(self, bus, config, store_kwargs):
-        """
-        Creates a new instance of the CherryPyInvestigatorPlugin.
-
-        :param bus: The CherryPy bus.
-        :type bus: cherrypy.process.wspbus.Bus
-        :param config: Configuration information.
-        :type config: commissaire.config.Config
-        :param store_kwargs: Keyword arguments used to make the etcd client.
-        :type store_kwargs: dict
-        """
-        plugins.SimplePlugin.__init__(self, bus)
-        self.process = Process(
-            target=investigator,
-            args=(INVESTIGATE_QUEUE, config, store_kwargs))
-        self.process.daemon = True
-        self.bus.subscribe('investigator-is-alive', self.is_alive)
-
-    def start(self):
-        """
-        Starts the investigator process.
-        """
-        self.process.start()
-
-    def is_alive(self):
-        """
-        Returns whether the investigator process object is alive.
-
-        The investigator process object is alive from the moment the
-        start() method returns until the child process terminates.
-
-        :returns: Whether the investigator is alive
-        :rtype: bool
-        """
-        return self.process.is_alive()
-
-
-class CherryPyStorePlugin(plugins.SimplePlugin):
+class StorePlugin(plugins.SimplePlugin):
 
     def __init__(self, bus, store_kwargs):
         """
@@ -180,3 +137,7 @@ class CherryPyStorePlugin(plugins.SimplePlugin):
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)
+
+
+#: Generic name for the plugin
+Plugin = StorePlugin

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -257,8 +257,8 @@ def main():  # pragma: no cover
     """
     Main script entry point.
     """
-    from commissaire.cherrypy_plugins import (
-        CherryPyStorePlugin, CherryPyInvestigatorPlugin)
+    from commissaire.cherrypy_plugins.store import StorePlugin
+    from commissaire.cherrypy_plugins.investigator import InvestigatorPlugin
     config = Config()
 
     epilog = ('Example: ./commissaire -e http://127.0.0.1:2379'
@@ -407,8 +407,8 @@ def main():  # pragma: no cover
         cherrypy.engine.signal_handler.subscribe()
 
     # Add our plugins
-    CherryPyStorePlugin(cherrypy.engine, store_kwargs).subscribe()
-    CherryPyInvestigatorPlugin(
+    StorePlugin(cherrypy.engine, store_kwargs).subscribe()
+    InvestigatorPlugin(
         cherrypy.engine, config, store_kwargs).subscribe()
 
     # NOTE: Anything that requires etcd should start AFTER

--- a/test/test_cherrypy_plugins_investigator.py
+++ b/test/test_cherrypy_plugins_investigator.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire.cherrypy_plugins.investigator module.
+"""
+
+import mock
+
+from . import TestCase
+from commissaire.cherrypy_plugins.investigator import Plugin
+
+
+class Test_InvestigatorPlugin(TestCase):
+    """
+    Tests for the InvestigatorPlugin class.
+    """
+
+    #: Topics that should be registered
+    topics = ('investigator-is-alive', )
+
+    def before(self):
+        """
+        Called before every test.
+        """
+        self.bus = mock.MagicMock()
+        self.store_kwargs = {}
+        self.plugin = Plugin(self.bus, {}, self.store_kwargs)
+
+    def after(self):
+        """
+        Called after every test.
+        """
+        self.bus = None
+        self.plugin = None
+
+    def test_investigator_plugin_creation(self):
+        """
+        Verify that the creation of the plugin works as it should.
+        """
+        # The processes should not have started yet
+        self.assertFalse(self.plugin.is_alive())
+
+        # There should be bus subscribed topics
+        for topic in self.topics:
+            self.bus.subscribe.assert_any_call(topic, mock.ANY)
+
+    def test_investigator_plugin_start(self):
+        """
+        Verify start() starts the background process.
+        """
+        self.plugin.start()
+        self.assertTrue(self.plugin.is_alive())
+        self.plugin.stop()
+
+    def test_investigator_plugin_stop(self):
+        """
+        Verify stop() unsubscribes topics and terminates the process.
+        """
+        self.plugin.start()
+        self.plugin.stop()
+        # unsubscribe should be called a specific number of times
+        self.assertEquals(len(self.topics), self.bus.unsubscribe.call_count)
+        # Each unsubscription should have it's own call
+        # to deregister a callback
+        for topic in self.topics:
+            self.bus.unsubscribe.assert_any_call(topic, mock.ANY)
+        self.assertFalse(self.plugin.is_alive())

--- a/test/test_cherrypy_plugins_investigator.py
+++ b/test/test_cherrypy_plugins_investigator.py
@@ -60,13 +60,14 @@ class Test_InvestigatorPlugin(TestCase):
         """
         Verify start() starts the background process.
         """
+        self.assertFalse(self.plugin.is_alive())
         self.plugin.start()
         self.assertTrue(self.plugin.is_alive())
         self.plugin.stop()
 
     def test_investigator_plugin_stop(self):
         """
-        Verify stop() unsubscribes topics and terminates the process.
+        Verify stop() unsubscribes topics.
         """
         self.plugin.start()
         self.plugin.stop()
@@ -76,4 +77,3 @@ class Test_InvestigatorPlugin(TestCase):
         # to deregister a callback
         for topic in self.topics:
             self.bus.unsubscribe.assert_any_call(topic, mock.ANY)
-        self.assertFalse(self.plugin.is_alive())

--- a/test/test_cherrypy_plugins_store.py
+++ b/test/test_cherrypy_plugins_store.py
@@ -13,18 +13,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-Test cases for the commissaire.cherrypy_plugins module.
+Test cases for the commissaire.cherrypy_plugins.store module.
 """
 
 import mock
 
 from . import TestCase
-from commissaire import cherrypy_plugins
+from commissaire.cherrypy_plugins.store import Plugin
 
 
-class Test_CherryPyStorePlugin(TestCase):
+class Test_StorePlugin(TestCase):
     """
-    Tests for the CherryPyStorePlugin class.
+    Tests for the StorePlugin class.
     """
 
     #: Topics that should be registered
@@ -36,8 +36,7 @@ class Test_CherryPyStorePlugin(TestCase):
         """
         self.bus = mock.MagicMock()
         self.store_kwargs = {}
-        self.plugin = cherrypy_plugins.CherryPyStorePlugin(
-            self.bus, self.store_kwargs)
+        self.plugin = Plugin(self.bus, self.store_kwargs)
 
     def after(self):
         """
@@ -46,7 +45,7 @@ class Test_CherryPyStorePlugin(TestCase):
         self.bus = None
         self.plugin = None
 
-    def test_cherrypy_store_plugin_creation(self):
+    def test_store_plugin_creation(self):
         """
         Verify that the creation of the plugin works as it should.
         """
@@ -56,7 +55,7 @@ class Test_CherryPyStorePlugin(TestCase):
             # The Store should not have been called in any way
             self.assertEquals(0, _store().call_count)
 
-    def test_cherrypy_store_plugin__get_store(self):
+    def test_store_plugin__get_store(self):
         """
         Verify _get_store properly obtains a store instance.
         """
@@ -68,7 +67,7 @@ class Test_CherryPyStorePlugin(TestCase):
             self.assertEquals(store, _store())
             self.assertEquals(store, self.plugin.store)
 
-    def test_cherrypy_store_plugin_start(self):
+    def test_store_plugin_start(self):
         """
         Verify start() subscribes the proper topics.
         """
@@ -79,7 +78,7 @@ class Test_CherryPyStorePlugin(TestCase):
         for topic in self.topics:
             self.bus.subscribe.assert_any_call(topic, mock.ANY)
 
-    def test_cherrypy_store_plugin_stop(self):
+    def test_store_plugin_stop(self):
         """
         Verify stop() unsubscribes the proper topics.
         """
@@ -91,7 +90,7 @@ class Test_CherryPyStorePlugin(TestCase):
         for topic in self.topics:
             self.bus.unsubscribe.assert_any_call(topic, mock.ANY)
 
-    def test_cherrypy_store_save(self):
+    def test_store_save(self):
         """
         Verify store_save handles data properly.
         """
@@ -107,7 +106,7 @@ class Test_CherryPyStorePlugin(TestCase):
             # The result should be a tuple
             self.assertEquals((expected_result, None), result)
 
-    def test_cherrypy_store_save_error(self):
+    def test_store_save_error(self):
         """
         Verify store_save handles errors properly.
         """
@@ -123,7 +122,7 @@ class Test_CherryPyStorePlugin(TestCase):
             # The result should be a tuple
             self.assertEquals(([], expected_result), result)
 
-    def test_cherrypy_store_get(self):
+    def test_store_get(self):
         """
         Verify store_get returns data properly.
         """
@@ -138,7 +137,7 @@ class Test_CherryPyStorePlugin(TestCase):
             # The result should be a tuple
             self.assertEquals((expected_result, None), result)
 
-    def test_cherrypy_store_get_error(self):
+    def test_store_get_error(self):
         """
         Verify store_get returns errors properly.
         """


### PR DESCRIPTION
This splits out the plugins inside of the original `cherrypy_plugin`s module into a `cherrypy_plugins` package and removes some redundant naming. It also adds in a missing unittest for the investigator plugin.