### PR TITLE
[merged] Add debug output to StorePlugin.

### DIFF
--- a/conf/logger.json
+++ b/conf/logger.json
@@ -58,6 +58,11 @@
             "level": "INFO",
             "propagate": false
         },
+        "store": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": false
+        },
         "transport": {
             "handlers": ["console"],
             "level": "INFO",

--- a/src/commissaire/cherrypy_plugins/store.py
+++ b/src/commissaire/cherrypy_plugins/store.py
@@ -16,6 +16,7 @@
 Custom CherryPy plugins for commissaire.
 """
 
+import logging
 import sys
 
 import etcd
@@ -35,6 +36,7 @@ class StorePlugin(plugins.SimplePlugin):
         :type store_kwargs: dict
         """
         plugins.SimplePlugin.__init__(self, bus)
+        self.logger = logging.getLogger('store')
         self.store_kwargs = store_kwargs
         self.store = None
 
@@ -85,7 +87,10 @@ class StorePlugin(plugins.SimplePlugin):
         """
         try:
             store = self._get_store()
-            return (store.write(key, json_entity, **kwargs), None)
+            self.logger.debug('> SAVE {0} : {1}'.format(key, json_entity))
+            response = store.write(key, json_entity, **kwargs)
+            self.logger.debug('< SAVE {0} : {1}'.format(key, response.value))
+            return (response, None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)
@@ -101,7 +106,10 @@ class StorePlugin(plugins.SimplePlugin):
         """
         try:
             store = self._get_store()
-            return (store.get(key), None)
+            self.logger.debug('> GET {0}'.format(key))
+            response = store.get(key)
+            self.logger.debug('< GET {0} : {1}'.format(key, response))
+            return (response, None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)
@@ -117,7 +125,10 @@ class StorePlugin(plugins.SimplePlugin):
         """
         try:
             store = self._get_store()
-            return (store.delete(key), None)
+            self.logger.debug('> DELETE {0}'.format(key))
+            response = store.delete(key)
+            self.logger.debug('< DELETE {0} : {1}'.format(key, response))
+            return (response, None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)
@@ -133,7 +144,10 @@ class StorePlugin(plugins.SimplePlugin):
         """
         try:
             store = self._get_store()
-            return (store.read(key, recursive=True), None)
+            self.logger.debug('> LIST {0}'.format(key))
+            response = store.read(key, recursive=True)
+            self.logger.debug('< LIST {0} : {1}'.format(key, response))
+            return (response, None)
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)

--- a/src/commissaire/cherrypy_plugins/store.py
+++ b/src/commissaire/cherrypy_plugins/store.py
@@ -89,7 +89,7 @@ class StorePlugin(plugins.SimplePlugin):
             store = self._get_store()
             self.logger.debug('> SAVE {0} : {1}'.format(key, json_entity))
             response = store.write(key, json_entity, **kwargs)
-            self.logger.debug('< SAVE {0} : {1}'.format(key, response.value))
+            self.logger.debug('< SAVE {0} : {1}'.format(key, response))
             return (response, None)
         except:
             _, exc, _ = sys.exc_info()

--- a/test/test_cherrypy_plugins_store.py
+++ b/test/test_cherrypy_plugins_store.py
@@ -99,6 +99,7 @@ class Test_StorePlugin(TestCase):
         with mock.patch('etcd.Client') as _store:
             store = _store()
             expected_result = mock.MagicMock('etcd.EtcdResult')
+            expected_result.value = {}
             store.write.return_value = expected_result
             result = self.plugin.store_save(key, data)
             # The store should be called to set the data


### PR DESCRIPTION
Needed some extra debug hooks.

This is disabled by default because it overwhelms the server log.