### PR TITLE
[merged] doc: run_from_source example now uses pip.

### DIFF
--- a/doc/examples/run_from_source.rst
+++ b/doc/examples/run_from_source.rst
@@ -1,6 +1,7 @@
 
 .. code-block:: shell
 
-   (virtualenv)$ PYTHONPATH=`pwd`/src python src/commissaire/script.py \
-       --config-file=/etc/commissaire/commissaire.conf &
+   (virtualenv)$ pip install -e /path/to/commissaire/checkout
+   ...
+   (virtualenv)$ commissaire --config-file=/etc/commissaire/commissaire.conf &
    ...


### PR DESCRIPTION
In the olden days PYTHONPATH stuff was needed when running items from source.
pip install -e supersedes the old way.