### PR TITLE
[merged] Store handler manager

### DIFF
--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -27,7 +27,7 @@ from commissaire.jobs.investigator import investigator
 
 class InvestigatorPlugin(plugins.SimplePlugin):
 
-    def __init__(self, bus, config, store_kwargs):
+    def __init__(self, bus, config):
         """
         Creates a new instance of the InvestigatorPlugin.
 
@@ -35,8 +35,6 @@ class InvestigatorPlugin(plugins.SimplePlugin):
         :type bus: cherrypy.process.wspbus.Bus
         :param config: Configuration information.
         :type config: commissaire.config.Config
-        :param store_kwargs: Keyword arguments used to make the etcd client.
-        :type store_kwargs: dict
         """
         plugins.SimplePlugin.__init__(self, bus)
         # multiprocessing.Process() uses fork() to execute the target
@@ -51,7 +49,7 @@ class InvestigatorPlugin(plugins.SimplePlugin):
         self.main_pid = os.getpid()
         self.process = Process(
             target=investigator,
-            args=(INVESTIGATE_QUEUE, config, store_kwargs))
+            args=(INVESTIGATE_QUEUE, config))
         # TODO: Move to start()
         self.bus.subscribe('investigator-is-alive', self.is_alive)
 

--- a/src/commissaire/cherrypy_plugins/store.py
+++ b/src/commissaire/cherrypy_plugins/store.py
@@ -56,6 +56,7 @@ class StorePlugin(plugins.SimplePlugin):
         self.bus.subscribe("store-get", self.store_get)
         self.bus.subscribe("store-delete", self.store_delete)
         self.bus.subscribe("store-list", self.store_list)
+        self.bus.subscribe("store-manager-clone", self.store_manager_clone)
 
     def stop(self):
         """
@@ -66,6 +67,7 @@ class StorePlugin(plugins.SimplePlugin):
         self.bus.unsubscribe("store-get", self.store_get)
         self.bus.unsubscribe("store-delete", self.store_delete)
         self.bus.unsubscribe("store-list", self.store_list)
+        self.bus.unsubscribe("store-manager-clone", self.store_manager_clone)
 
     def store_save(self, key, json_entity, **kwargs):
         """
@@ -142,6 +144,15 @@ class StorePlugin(plugins.SimplePlugin):
         except:
             _, exc, _ = sys.exc_info()
             return ([], exc)
+
+    def store_manager_clone(self):
+        """
+        Creates a cloned instance of the configured StoreHandlerManager.
+
+        :returns: A cloned StoreHandlerManager
+        :rtype: commissaire.store.StoreHandlerManager
+        """
+        return self.manager.clone()
 
 
 #: Generic name for the plugin

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -19,6 +19,7 @@ Cluster(s) handlers.
 import datetime
 import json
 
+import cherrypy
 import falcon
 
 from multiprocessing import Process
@@ -428,8 +429,9 @@ class ClusterDeployResource(Resource):
         except:
             pass
 
-        p = Process(target=clusterexec,
-                    args=(name, 'deploy', {'version': version}))
+        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
+        args = (store_manager, name, 'deploy', {'version': version})
+        p = Process(target=clusterexec, args=args)
         p.start()
         self.logger.debug(
             'Started deployment to {0} in clusterexecpool for {1}'.format(
@@ -521,7 +523,9 @@ class ClusterRestartResource(Resource):
             pass
 
         # TODO: Move to a poll?
-        p = Process(target=clusterexec, args=(name, 'restart'))
+        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
+        args = (store_manager, name, 'restart')
+        p = Process(target=clusterexec, args=args)
         p.start()
 
         self.logger.debug('Started restart in clusterexecpool for {0}'.format(
@@ -615,7 +619,9 @@ class ClusterUpgradeResource(Resource):
             pass
 
         # TODO: Move to a poll?
-        p = Process(target=clusterexec, args=(name, 'upgrade'))
+        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
+        args = (store_manager, name, 'upgrade')
+        p = Process(target=clusterexec, args=args)
         p.start()
 
         self.logger.debug('Started upgrade in clusterexecpool for {0}'.format(

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -228,6 +228,8 @@ def etcd_host_create(address, ssh_priv_key, remote_user, cluster_name=None):
     if cluster_name:
         etcd_cluster_add_host(cluster_name, address)
 
-    INVESTIGATE_QUEUE.put((host_creation, ssh_priv_key, remote_user))
+    store_manager = cherrypy.engine.publish('store-manager-clone')[0]
+    job_request = (store_manager, host_creation, ssh_priv_key, remote_user)
+    INVESTIGATE_QUEUE.put(job_request)
 
     return (falcon.HTTP_201, Host(**json.loads(new_host.value)))

--- a/src/commissaire/model.py
+++ b/src/commissaire/model.py
@@ -21,7 +21,7 @@ import json
 import cherrypy
 
 
-class Model:
+class Model(object):
     """
     Parent class for models.
     """

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -406,8 +406,7 @@ def main():  # pragma: no cover
 
     # Add our plugins
     StorePlugin(cherrypy.engine, store_kwargs).subscribe()
-    InvestigatorPlugin(
-        cherrypy.engine, config, store_kwargs).subscribe()
+    InvestigatorPlugin(cherrypy.engine, config).subscribe()
 
     # NOTE: Anything that requires etcd should start AFTER
     # the engine is started

--- a/src/commissaire/store/etcdstoreplugin.py
+++ b/src/commissaire/store/etcdstoreplugin.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import etcd
+
+from commissaire.store import StoreHandlerBase
+
+
+class EtcdStorePlugin(StoreHandlerBase):
+    """
+    Handler for data storage on etcd.
+    """
+
+    def __init__(self, config):
+        """
+        Creates a new instance of EtcdStorePlugin.
+
+        :param config: Configuration details
+        :type config: dict
+        """
+        self._store = etcd.Client(**config)
+
+    def _save(self, key, json_entity):
+        """
+        Saves data to etcd and returns back a saved model.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information and data to save.  But for now this
+           takes an etcd path and JSON string.
+
+        :param model_instance: Model instance to save
+        :type model_instance: commissaire.model.Model
+        :returns: The saved model instance
+        :rtype: commissaire.model.Model
+        """
+        return self._store.write(key, json_entity)
+
+    def _get(self, key):
+        """
+        Returns data from a store and returns back a model.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to search and get
+        :type model_instance: commissaire.model.Model
+        :returns: The saved model instance
+        :rtype: commissaire.model.Model
+        """
+        return self._store.get(key)
+
+    def _delete(self, key):
+        """
+        Deletes data from a store.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to delete
+        :type model_instance:
+        """
+        return self._store.delete(key)
+
+    def _list(self, key):
+        """
+        Lists data at a location in a store and returns back model instances.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to search for and list
+        :type model_instance: commissaire.model.Model
+        :returns: A list of models
+        :rtype: list
+        """
+        return self._store.read(key, recursive=True)
+
+
+StoreHandler = EtcdStorePlugin

--- a/src/commissaire/store/storehandlermanager.py
+++ b/src/commissaire/store/storehandlermanager.py
@@ -1,0 +1,142 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from copy import deepcopy
+
+# XXX Temporary until we have a real storage plugin system.
+from commissaire.model import Model as BogusModelType
+
+
+class StoreHandlerManager(object):
+    """
+    Configures StoreHandler instances and routes storage requests to
+    the appropriate instance.
+    """
+
+    def __init__(self):
+        """
+        Creates a new StoreHandlerManager instance.
+        """
+        self._registry = {}
+        self._handlers = {}
+
+        # XXX Temporary, until we're passing models instead of keys.
+        self.bogus_model = BogusModelType()
+
+    def clone(self):
+        """
+        Creates a copy of a StoreHandlerManager with the same configuration
+        but no connections.
+        """
+        clone = StoreHandlerManager()
+        clone._registry = deepcopy(self._registry)
+        # clone._handlers should remain empty.
+        return clone
+
+    def register_store_handler(self, handler_type, config, *model_types):
+        """
+        Associates a StoreHandler subclass with one or more model types.
+
+        :param handler_type: A class derived from StoreHandler
+        :type handler_type: type
+        :param config: Configuration parameters for the handler
+        :type config: dict
+        :param model_types: Model types under the handler's purview
+        :type module_types: tuple
+        """
+        entry = (handler_type, config, model_types)
+        self._registry.update({mt: entry for mt in model_types})
+
+    def _get_handler(self, model):
+        """
+        Looks up, and if necessary instantiates, a StoreHandler instance
+        for the given model.  Raises KeyError if no handler is registered
+        for that type of model.
+        """
+        handler = self._handlers.get(type(model))
+        if handler is None:
+            # Let this raise a KeyError if the registry lookup fails.
+            handler_type, config, model_types = self._registry[type(model)]
+            handler = handler_type(config)
+            self._handlers.update({mt: handler for mt in model_types})
+        return handler
+
+    def save(self, key, json_entity):
+        """
+        Saves data to a store and returns back a saved model.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information and data to save.  But for now this
+           takes an etcd path and JSON string.
+
+        :param model_instance: Model instance to save
+        :type model_instance: commissaire.model.Model
+        :returns: The saved model instance
+        :rtype: commissaire.model.Model
+        """
+        handler = self._get_handler(self.bogus_model)
+        return handler._save(key, json_entity)
+
+    def get(self, key):
+        """
+        Returns data from a store and returns back a model.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to search and get
+        :type model_instance: commissaire.model.Model
+        :returns: The saved model instance
+        :rtype: commissaire.model.Model
+        """
+        handler = self._get_handler(self.bogus_model)
+        return handler._get(key)
+
+    def delete(self, key):
+        """
+        Deletes data from a store.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to delete
+        :type model_instance:
+        """
+        handler = self._get_handler(self.bogus_model)
+        return handler._delete(key)
+
+    def list(self, key):
+        """
+        Lists data at a location in a store and returns back model instances.
+
+        .. note::
+
+           Eventually this method will take a model instance containing
+           identifying information.  But for now this takes an etcd path.
+
+        :param model_instance: Model instance to search for and list
+        :type model_instance: commissaire.model.Model
+        :returns: A list of models
+        :rtype: list
+        """
+        handler = self._get_handler(self.bogus_model)
+        return handler._list(key)

--- a/test/test_cherrypy_plugins_investigator.py
+++ b/test/test_cherrypy_plugins_investigator.py
@@ -35,8 +35,7 @@ class Test_InvestigatorPlugin(TestCase):
         Called before every test.
         """
         self.bus = mock.MagicMock()
-        self.store_kwargs = {}
-        self.plugin = Plugin(self.bus, {}, self.store_kwargs)
+        self.plugin = Plugin(self.bus, {})
 
     def after(self):
         """

--- a/test/test_cherrypy_plugins_store.py
+++ b/test/test_cherrypy_plugins_store.py
@@ -28,7 +28,11 @@ class Test_StorePlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('store-get', 'store-save', 'store-delete', 'store-list')
+    topics = ('store-get',
+              'store-save',
+              'store-delete',
+              'store-list',
+              'store-manager-clone')
 
     def before(self):
         """
@@ -44,28 +48,6 @@ class Test_StorePlugin(TestCase):
         """
         self.bus = None
         self.plugin = None
-
-    def test_store_plugin_creation(self):
-        """
-        Verify that the creation of the plugin works as it should.
-        """
-        with mock.patch('etcd.Client') as _store:
-            # Store should be None
-            self.assertEquals(None, self.plugin.store)
-            # The Store should not have been called in any way
-            self.assertEquals(0, _store().call_count)
-
-    def test_store_plugin__get_store(self):
-        """
-        Verify _get_store properly obtains a store instance.
-        """
-        with mock.patch('etcd.Client') as _store:
-            store = self.plugin._get_store()
-            # We should have a store created with our kwargs
-            _store.assert_called_once_with(**self.store_kwargs)
-            # The returned stoer should be exactly the same
-            self.assertEquals(store, _store())
-            self.assertEquals(store, self.plugin.store)
 
     def test_store_plugin_start(self):
         """

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -26,6 +26,7 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import clusters
 from commissaire.middleware import JSONify
+from commissaire.store.storehandlermanager import StoreHandlerManager
 
 
 class Test_Clusters(TestCase):
@@ -313,6 +314,7 @@ class Test_ClusterRestartResource(TestCase):
             _publish.side_effect = (
                 [[MagicMock(value=self.etcd_cluster), None]],
                 [[[], etcd.EtcdKeyNotFound]],
+                [MagicMock(StoreHandlerManager)],
                 [[MagicMock(etcd.EtcdResult, value=self.arestart), None]])
 
             body = self.simulate_request(
@@ -555,7 +557,7 @@ class Test_ClusterUpgradeResource(TestCase):
 
     def test_cluster_upgrade_create(self):
         """
-        Verify creating a cluster.
+        Verify creating a cluster upgrade.
         """
         # etcd.Client Patched to avoid the internal connection
         # Process is patched because we don't want to exec the subprocess
@@ -567,6 +569,7 @@ class Test_ClusterUpgradeResource(TestCase):
             _publish.side_effect = (
                 [[MagicMock(value=self.etcd_cluster), None]],
                 [[[], etcd.EtcdKeyNotFound]],
+                [MagicMock(StoreHandlerManager)],
                 [[MagicMock(etcd.EtcdResult, value=self.aupgrade), None]])
 
             # Verify with creation

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -26,6 +26,7 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import hosts
 from commissaire.middleware import JSONify
+from commissaire.store.storehandlermanager import StoreHandlerManager
 
 
 class Test_Hosts(TestCase):
@@ -293,7 +294,8 @@ class Test_HostResource(TestCase):
                 [[MagicMock(value=self.etcd_host), None]],
                 [[MagicMock(value=self.etcd_host), None]],
                 [[MagicMock(value=self.etcd_cluster), None]],
-                [[MagicMock(value=self.etcd_cluster), None]])
+                [[MagicMock(value=self.etcd_cluster), None]],
+                [MagicMock(StoreHandlerManager)])
             data = ('{"ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                     ' "cluster": "testing"}')
             body = self.simulate_request(
@@ -381,7 +383,8 @@ class Test_ImplicitHostResource(TestCase):
                 [[MagicMock(value=self.etcd_host), None]],
                 [[MagicMock(value=self.etcd_host), None]],
                 [[MagicMock(value=self.etcd_cluster), None]],
-                [[MagicMock(value=self.etcd_host), None]])
+                [[MagicMock(value=self.etcd_host), None]],
+                [MagicMock(StoreHandlerManager)])
 
             data = ('{"ssh_priv_key": "dGVzdAo=", "remote_user": "root",'
                     ' "cluster": "testing"}')

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -23,6 +23,7 @@ from . import TestCase
 from commissaire.compat.urlparser import urlparse
 
 from commissaire.jobs.investigator import clean_up_key, investigator
+from commissaire.store.storehandlermanager import StoreHandlerManager
 from Queue import Queue
 from mock import MagicMock
 
@@ -58,9 +59,7 @@ class Test_JobsInvestigator(TestCase):
         """
         Verify the investigator.
         """
-        with mock.patch('commissaire.transport.ansibleapi.Transport') as _tp, \
-             mock.patch('etcd.Client.get') as _etcd_get, \
-             mock.patch('etcd.Client.write') as _etcd_write:
+        with mock.patch('commissaire.transport.ansibleapi.Transport') as _tp:
 
             _tp().get_info.return_value = (
                 0,
@@ -73,9 +72,6 @@ class Test_JobsInvestigator(TestCase):
             )
 
             q = Queue()
-
-            _etcd_get.return_value = MagicMock(
-                'etcd.EtcdResult', value=self.etcd_host)
 
             to_investigate = {
                 'address': '10.0.0.2',
@@ -92,8 +88,12 @@ class Test_JobsInvestigator(TestCase):
                 }
             }
 
-            q.put_nowait((to_investigate, ssh_priv_key, 'root'))
+            manager = MagicMock(StoreHandlerManager)
+            manager.get.return_value = MagicMock(
+                'etcd.EtcdResult', value=self.etcd_host)
+
+            q.put_nowait((manager, to_investigate, ssh_priv_key, 'root'))
             investigator(q, connection_config, run_once=True)
 
-            self.assertEquals(1, _etcd_get.call_count)
-            self.assertEquals(2, _etcd_write.call_count)
+            self.assertEquals(1, manager.get.call_count)
+            self.assertEquals(2, manager.save.call_count)


### PR DESCRIPTION
This ties in to [CPD-126](https://github.com/projectatomic/commissaire/wiki/cpd-126) as an extra layer between `CherryPyStorePlugin` and various `StoreHandler` instances.  The idea is `StoreHandlerManager` can be cloned with an identical configuration and handed off to child processes so they can read and write to the appropriate stores while avoiding the forked CherryPy bus.

A couple small deviations from CPD-126:

 1. The `register_store_handler()` method takes a type object and a configuration object instead of a `StoreHandler` instance.  The type object should be derived from the `StoreHandlerBase` class.  `StoreHandlerManager` will lazily create `StoreHandler` instances as needed, and these instances are NOT duplicated in cloned `StoreHandlerManager`s.

 2. Consequently, `StoreHandler` instances can go ahead and connect to their stores immediately.  So the `_get_connection()` method is no longer needed.

Note the API still takes etcd key paths instead of model instances.
This is temporary so we can implement and test CPD-126 incrementally.

@ashcrow: Code's ready for review if you have time.  So far so good with BDD and manual tests.  Unit tests are always a pain; I'll finish them Friday.