### PR TITLE
[merged] Simplify StorePlugin bus API.

### DIFF
--- a/src/commissaire/authentication/httpbasicauth.py
+++ b/src/commissaire/authentication/httpbasicauth.py
@@ -52,16 +52,18 @@ class HTTPBasicAuth(Authenticator):
         """
         Loads authentication information from etcd.
         """
-        d, error = cherrypy.engine.publish(
-            'store-get', '/commissaire/config/httpbasicauthbyuserlist')[0]
-
-        if error:
-            if type(error) == ValueError:
-                self.logger.warn(
-                    'User configuration in Etcd is not valid JSON. Raising...')
-            else:
-                self.logger.warn(
-                    'User configuration not found in Etcd. Raising...')
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        try:
+            key = '/commissaire/config/httpbasicauthbyuserlist'
+            d = store_manager.get(key)
+        except ValueError as error:
+            self.logger.warn(
+                'User configuration in Etcd is not valid JSON. Raising...')
+            self._data = {}
+            raise error
+        except Exception as error:
+            self.logger.warn(
+                'User configuration not found in Etcd. Raising...')
             self._data = {}
             raise error
 

--- a/src/commissaire/cherrypy_plugins/store.py
+++ b/src/commissaire/cherrypy_plugins/store.py
@@ -16,143 +16,43 @@
 Custom CherryPy plugins for commissaire.
 """
 
-import logging
-import sys
-
 from cherrypy.process import plugins
 
 from commissaire.store.storehandlermanager import StoreHandlerManager
 
-# XXX Temporary until we have a real storage plugin system.
-from commissaire.model import Model as BogusModelType
-from commissaire.store.etcdstoreplugin import EtcdStorePlugin
-
 
 class StorePlugin(plugins.SimplePlugin):
 
-    def __init__(self, bus, store_kwargs):
+    def __init__(self, bus):
         """
         Creates a new instance of the CherryPyStorePlugin.
 
         :param bus: The CherryPy bus.
         :type bus: cherrypy.process.wspbus.Bus
-        :param store_kwargs: Keyword arguments used to make the Client.
-        :type store_kwargs: dict
         """
         plugins.SimplePlugin.__init__(self, bus)
-        self.logger = logging.getLogger('store')
         self.manager = StoreHandlerManager()
-
-        # XXX Temporary until we have a real storage plugin system.
-        self.manager.register_store_handler(
-            EtcdStorePlugin, store_kwargs, BogusModelType)
 
     def start(self):
         """
         Starts the plugin.
         """
         self.bus.log('Starting up Store access')
-        self.bus.subscribe("store-save", self.store_save)
-        self.bus.subscribe("store-get", self.store_get)
-        self.bus.subscribe("store-delete", self.store_delete)
-        self.bus.subscribe("store-list", self.store_list)
-        self.bus.subscribe("store-manager-clone", self.store_manager_clone)
+        self.bus.subscribe('get-store-manager', self.get_store_manager)
 
     def stop(self):
         """
         Stops the plugin.
         """
         self.bus.log('Stopping down Store access')
-        self.bus.unsubscribe("store-save", self.store_save)
-        self.bus.unsubscribe("store-get", self.store_get)
-        self.bus.unsubscribe("store-delete", self.store_delete)
-        self.bus.unsubscribe("store-list", self.store_list)
-        self.bus.unsubscribe("store-manager-clone", self.store_manager_clone)
+        self.bus.unsubscribe('get-store-manager', self.get_store_manager)
 
-    def store_save(self, key, json_entity, **kwargs):
+    def get_store_manager(self):
         """
-        Saves json to the store.
-
-        :param key: The key to associate the data with.
-        :type key: str
-        :param json_entity: The json data to save.
-        :type json_entity: str
-        :param kwargs: All other keyword-args to pass to client
-        :type kwargs: dict
-        :returns: The stores response and any errors that may have occured
-        :rtype: tuple(etcd.EtcdResult, Exception)
+        :returns: The global StoreHandlerManager instance
+        :rtype: commissaire.store.storehandlermanager.StoreHandlerManager
         """
-        try:
-            self.logger.debug('> SAVE {0} : {1}'.format(key, json_entity))
-            response = self.manager.save(key, json_entity)
-            self.logger.debug('< SAVE {0} : {1}'.format(key, response))
-            return (response, None)
-        except:
-            _, exc, _ = sys.exc_info()
-            return ([], exc)
-
-    def store_get(self, key):
-        """
-        Retrieves json from the store.
-
-        :param key: The key to associate the data with.
-        :type key: str
-        :returns: The stores response and any errors that may have occured
-        :rtype: tuple(etcd.EtcdResult, Exception)
-        """
-        try:
-            self.logger.debug('> GET {0}'.format(key))
-            response = self.manager.get(key)
-            self.logger.debug('< GET {0} : {1}'.format(key, response))
-            return (response, None)
-        except:
-            _, exc, _ = sys.exc_info()
-            return ([], exc)
-
-    def store_delete(self, key):
-        """
-        Deletes json from the store.
-
-        :param key: The key to associate the data with.
-        :type key: str
-        :returns: The stores response and any errors that may have occured
-        :rtype: tuple(etcd.EtcdResult, Exception)
-        """
-        try:
-            self.logger.debug('> DELETE {0}'.format(key))
-            response = self.manager.delete(key)
-            self.logger.debug('< DELETE {0} : {1}'.format(key, response))
-            return (response, None)
-        except:
-            _, exc, _ = sys.exc_info()
-            return ([], exc)
-
-    def store_list(self, key):
-        """
-        Lists a directory.
-
-        :param key: The key to associate the data with.
-        :type key: str
-        :returns: The stores response and any errors that may have occured
-        :rtype: tuple(etcd.EtcdResult, Exception)
-        """
-        try:
-            self.logger.debug('> LIST {0}'.format(key))
-            response = self.manager.list(key)
-            self.logger.debug('< LIST {0} : {1}'.format(key, response))
-            return (response, None)
-        except:
-            _, exc, _ = sys.exc_info()
-            return ([], exc)
-
-    def store_manager_clone(self):
-        """
-        Creates a cloned instance of the configured StoreHandlerManager.
-
-        :returns: A cloned StoreHandlerManager
-        :rtype: commissaire.store.StoreHandlerManager
-        """
-        return self.manager.clone()
+        return self.manager
 
 
 #: Generic name for the plugin

--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -80,10 +80,9 @@ class ClusterResource(Resource):
         #      the host data in one etcd call and sort through
         #      them, or fetch the ones we need individually.
         #      For the MVP phase, fetch all is better.
-        # etcd_resp, error = cherrypy.engine.publish(
-        #     'store-get', '/commissaire/hosts')[0]
+        # store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        # etcd_resp = store_manager.get('/commissaire/hosts')
 
-        # if error:
         try:
             hosts = Hosts.retrieve()
         except:
@@ -117,8 +116,6 @@ class ClusterResource(Resource):
         """
         try:
             cluster = Cluster.retrieve(name)
-            # key = util.etcd_cluster_key(name)
-            # etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
         except:
             resp.status = falcon.HTTP_404
             return
@@ -429,8 +426,8 @@ class ClusterDeployResource(Resource):
         except:
             pass
 
-        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
-        args = (store_manager, name, 'deploy', {'version': version})
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        args = (store_manager.clone(), name, 'deploy', {'version': version})
         p = Process(target=clusterexec, args=args)
         p.start()
         self.logger.debug(
@@ -523,8 +520,8 @@ class ClusterRestartResource(Resource):
             pass
 
         # TODO: Move to a poll?
-        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
-        args = (store_manager, name, 'restart')
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        args = (store_manager.clone(), name, 'restart')
         p = Process(target=clusterexec, args=args)
         p.start()
 
@@ -619,8 +616,8 @@ class ClusterUpgradeResource(Resource):
             pass
 
         # TODO: Move to a poll?
-        store_manager = cherrypy.engine.publish('store-manager-clone')[0]
-        args = (store_manager, name, 'upgrade')
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        args = (store_manager.clone(), name, 'upgrade')
         p = Process(target=clusterexec, args=args)
         p.start()
 

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -126,7 +126,6 @@ class HostResource(Resource):
         :param address: The address of the Host being requested.
         :type address: str
         """
-        # TODO: Move to bus.publish
         try:
             # Extract what we need from the input data.
             # Don't treat it as a skeletal host record.
@@ -208,7 +207,6 @@ class ImplicitHostResource(Resource):
         :param resp: Response instance that will be passed through.
         :type resp: falcon.Response
         """
-        # TODO: Move this to bus.publish
         try:
             address = req.env['REMOTE_ADDR']
         except KeyError:

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -59,10 +59,8 @@ class Cluster(Model):
         :rtype: model
         """
         key = self._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish(
-            'store-save', key, self.to_json(secure=True))[0]
-        if error:
-            raise Exception(error)
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        store_manager.save(key, self.to_json(secure=True))
         return self
 
 
@@ -116,9 +114,8 @@ class Clusters(Model):
         :rtype: model
         """
         key = klass._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish('store-list', key)[0]
-        if error:
-            raise Exception(error)
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        etcd_resp = store_manager.list(key)
         clusters = []
         for x in etcd_resp.children:
             if etcd_resp.key != x.key:
@@ -159,7 +156,8 @@ class Hosts(Model):
         """
         key = klass._key.format(*parts)
         hosts = []
-        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        etcd_resp = store_manager.get(key)
 
         for host in etcd_resp.children:
             hosts.append(Host(**json.loads(host.value)))

--- a/src/commissaire/handlers/status.py
+++ b/src/commissaire/handlers/status.py
@@ -54,10 +54,11 @@ class StatusResource(Resource):
         resp.status = falcon.HTTP_503
 
         # Check etcd connection
-        root_dir, error = cherrypy.engine.publish('store-get', '/')[0]
-        if not error:
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        try:
+            store_manager.get('/')
             kwargs['etcd']['status'] = 'OK'
-        else:
+        except:
             self.logger.debug('There is no root directory in etcd...')
             kwargs['etcd']['status'] = 'FAILED'
 

--- a/src/commissaire/model.py
+++ b/src/commissaire/model.py
@@ -115,9 +115,8 @@ class Model(object):
         :rtype: model
         """
         key = klass._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish('store-get', key)[0]
-        if error:
-            raise Exception(error)
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        etcd_resp = store_manager.get(key)
         return klass(**json.loads(etcd_resp.value))
 
     def save(self, *parts):
@@ -129,10 +128,8 @@ class Model(object):
         :rtype: model
         """
         key = self._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish(
-            'store-save', key, self.to_json())[0]
-        if error:
-            raise Exception(error)
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        store_manager.save(key, self.to_json())
         return self
 
     @classmethod
@@ -144,7 +141,6 @@ class Model(object):
         :returns: None
         """
         key = klass._key.format(*parts)
-        etcd_resp, error = cherrypy.engine.publish('store-delete', key)[0]
-        if error:
-            raise Exception(error)
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        store_manager.delete(key)
         return None

--- a/test/test_authenticator_httpbasicauth.py
+++ b/test/test_authenticator_httpbasicauth.py
@@ -25,6 +25,7 @@ from falcon.testing.helpers import create_environ
 from commissaire.authentication import httpbasicauth
 from commissaire.authentication import httpauthclientcert
 from commissaire.ssl_adapter import SSL_CLIENT_VERIFY
+from commissaire.store.storehandlermanager import StoreHandlerManager
 
 class Test_HTTPBasicAuth(TestCase):
     """
@@ -152,7 +153,10 @@ class TestHTTPBasicAuthByEtcd(TestCase):
         Verify load raises when the key does not exist in etcd.
         """
         with mock.patch('cherrypy.engine.publish') as _publish:
-            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            manager.get.side_effect = etcd.EtcdKeyNotFound
 
             self.assertRaises(
                 etcd.EtcdKeyNotFound,
@@ -163,7 +167,10 @@ class TestHTTPBasicAuthByEtcd(TestCase):
         Verify load raises when the data in Etcd is bad.
         """
         with mock.patch('cherrypy.engine.publish') as _publish:
-            _publish.return_value = [[[], ValueError()]]
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            manager.get.side_effect = ValueError
 
             self.assertRaises(
                 ValueError,
@@ -179,7 +186,10 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             with open(self.user_config, 'r') as users_file:
                 return_value.value = users_file.read()
 
-            _publish.return_value = [[return_value, None]]
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            manager.get.return_value = return_value
 
             # Reload with the data from the mock'd Etcd
             http_basic_auth = httpbasicauth.HTTPBasicAuth()
@@ -201,7 +211,11 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             return_value = mock.MagicMock(etcd.EtcdResult)
             with open(self.user_config, 'r') as users_file:
                 return_value.value = users_file.read()
-            _publish.return_value = [[return_value, None]]
+
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            manager.get.return_value = return_value
 
             # Reload with the data from the mock'd Etcd
             http_basic_auth = httpbasicauth.HTTPBasicAuth()
@@ -223,7 +237,11 @@ class TestHTTPBasicAuthByEtcd(TestCase):
             return_value = mock.MagicMock(etcd.EtcdResult)
             with open(self.user_config, 'r') as users_file:
                 return_value.value = users_file.read()
-            _publish.return_value = [[return_value, None]]
+
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            manager.get.return_value = return_value
 
             # Reload with the data from the mock'd Etcd
             http_basic_auth = httpbasicauth.HTTPBasicAuth()

--- a/test/test_cherrypy_plugins_store.py
+++ b/test/test_cherrypy_plugins_store.py
@@ -20,6 +20,7 @@ import mock
 
 from . import TestCase
 from commissaire.cherrypy_plugins.store import Plugin
+from commissaire.store.storehandlermanager import StoreHandlerManager
 
 
 class Test_StorePlugin(TestCase):
@@ -28,19 +29,14 @@ class Test_StorePlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('store-get',
-              'store-save',
-              'store-delete',
-              'store-list',
-              'store-manager-clone')
+    topics = ('get-store-manager',)
 
     def before(self):
         """
         Called before every test.
         """
         self.bus = mock.MagicMock()
-        self.store_kwargs = {}
-        self.plugin = Plugin(self.bus, self.store_kwargs)
+        self.plugin = Plugin(self.bus)
 
     def after(self):
         """
@@ -72,65 +68,9 @@ class Test_StorePlugin(TestCase):
         for topic in self.topics:
             self.bus.unsubscribe.assert_any_call(topic, mock.ANY)
 
-    def test_store_save(self):
+    def test_get_store_manager(self):
         """
-        Verify store_save handles data properly.
+        Verify get_store_manager returns a store manager.
         """
-        key = '/test'
-        data = "{}"
-        with mock.patch('etcd.Client') as _store:
-            store = _store()
-            expected_result = mock.MagicMock('etcd.EtcdResult')
-            expected_result.value = {}
-            store.write.return_value = expected_result
-            result = self.plugin.store_save(key, data)
-            # The store should be called to set the data
-            store.write.assert_called_once_with(key, data)
-            # The result should be a tuple
-            self.assertEquals((expected_result, None), result)
-
-    def test_store_save_error(self):
-        """
-        Verify store_save handles errors properly.
-        """
-        key = '/test'
-        data = "{}"
-        with mock.patch('etcd.Client') as _store:
-            store = _store()
-            expected_result = Exception()
-            store.write.side_effect = expected_result
-            result = self.plugin.store_save(key, data)
-            # The store should be called to set the data
-            store.write.assert_called_once_with(key, data)
-            # The result should be a tuple
-            self.assertEquals(([], expected_result), result)
-
-    def test_store_get(self):
-        """
-        Verify store_get returns data properly.
-        """
-        key = '/test'
-        with mock.patch('etcd.Client') as _store:
-            store = _store()
-            expected_result = mock.MagicMock('etcd.EtcdResult')
-            store.get.return_value = expected_result
-            result = self.plugin.store_get(key)
-            # The store should be called to get the data
-            store.get.assert_called_once_with(key)
-            # The result should be a tuple
-            self.assertEquals((expected_result, None), result)
-
-    def test_store_get_error(self):
-        """
-        Verify store_get returns errors properly.
-        """
-        key = '/test'
-        with mock.patch('etcd.Client') as _store:
-            store = _store()
-            expected_result = Exception()
-            store.get.side_effect = expected_result
-            result = self.plugin.store_get(key)
-            # The store should be called to get the data
-            store.get.assert_called_once_with(key)
-            # The result should be a tuple
-            self.assertEquals(([], expected_result), result)
+        manager = self.plugin.get_store_manager()
+        self.assertIsInstance(manager, StoreHandlerManager)

--- a/test/test_handlers_status.py
+++ b/test/test_handlers_status.py
@@ -26,6 +26,7 @@ from . import TestCase
 from mock import MagicMock
 from commissaire.handlers import status
 from commissaire.middleware import JSONify
+from commissaire.store.storehandlermanager import StoreHandlerManager
 
 
 class Test_Status(TestCase):
@@ -67,10 +68,13 @@ class Test_StatusResource(TestCase):
         Verify retrieving Status.
         """
         with mock.patch('cherrypy.engine.publish') as _publish:
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
             child = MagicMock(value='')
             self.return_value._children = [child]
             self.return_value.leaves = self.return_value._children
-            _publish.return_value = [[self.return_value, None]]
+            manager.get.return_value = self.return_value
 
             body = self.simulate_request('/api/v0/status')
             self.assertEqual(self.srmock.status, falcon.HTTP_200)


### PR DESCRIPTION
Follow up from https://github.com/projectatomic/commissaire/pull/155.

Reduce the `StorePlugin` bus API to a single method: `get-store-handler`

Instead of proxying the entire `StoreHandlerManager` API, just return the `StoreHandlerManager` instance directly.

Whole bunch of unit tests exploded on me when I did this, so the changes there are just adapting them all so they work again.