### PR TITLE
[merged] Vagrant fixes to simply Kubernetes usage.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,9 @@ Vagrant.configure(2) do |config|
         echo "===> Starting etcd"
         sudo systemctl enable etcd
         sudo systemctl start etcd
+        echo "===> Set flannel network"
+        sudo etcdctl --endpoint=http://192.168.152.101:2379 set '/atomic01/network/config' '{"Network": "172.16.0.0/12", "SubnetLen": 24, "Backend": {"Type": "vxlan"}}'
+
       SHELL
     # End etcd
     end
@@ -58,6 +61,8 @@ Vagrant.configure(2) do |config|
         sudo hostnamectl set-hostname fedora-cloud
         echo "===> Updating the system"
         sudo dnf update --setopt=tsflags=nodocs -y
+        echo "===> Installing OS dependencies"
+        sudo dnf install -y python
       SHELL
     # End etcd
     end

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -31,15 +31,19 @@ virtualization system as well as vagrant installed and execute ``vagrant up``.
 
    The initial run updates the systems and can take some time. To provision faster try ``vagrant up --parallel etcd fedora-cloud fedora-atomic && vagrant up commissaire``.
 
-============== =============== ================ =========
-Server         IP              OS               AutoStart
-============== =============== ================ =========
-Etcd           192.168.152.101 Fedora Cloud 24  Yes
-Fedora Node    192.168.152.110 Fedora Cloud 24  Yes
-Fedora Atomic  192.168.152.111 Fedora Atomic 23 Yes
-Commissaire    192.168.152.100 Fedora Cloud 24  Yes
-Kubernetes     192.168.152.102 Fedora Cloud 24  No
-============== =============== ================ =========
+.. note::
+
+    You will need to add an ssh pub key to ``/root/.ssh/authorized_keys`` on nodes if you will not be using ``cloud-init`` for bootstrapping.
+
+================== =============== ================ =========
+Server             IP              OS               AutoStart
+================== =============== ================ =========
+Etcd               192.168.152.101 Fedora Cloud 24  Yes
+Fedora Node        192.168.152.110 Fedora Cloud 24  Yes
+Fedora Atomic Node 192.168.152.111 Fedora Atomic 23 Yes
+Commissaire        192.168.152.100 Fedora Cloud 24  Yes
+Kubernetes         192.168.152.102 Fedora Cloud 24  No
+================== =============== ================ =========
 
 For more information see the `Vagrant site <https://www.vagrantup.com>`_.
 


### PR DESCRIPTION
* Added note in development documentation about ssh keys.
* Fedora Node Server now installs python
* Etcd Server now sets the flannel network config

I think this will be the last follow related to ``Vagrant`` for a bit.