### PR TITLE
Added HostStatusResource as an endpoint.

### DIFF
--- a/doc/apidoc/commissaire.store.kubestorehandler.rst
+++ b/doc/apidoc/commissaire.store.kubestorehandler.rst
@@ -1,0 +1,7 @@
+commissaire.store.kubestorehandler module
+=========================================
+
+.. automodule:: commissaire.store.kubestorehandler
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -363,6 +363,69 @@ Retrieve a specific hosts credentials.
        "remote_user":  string, // name of ssh user to use for connections
    }
 
+HostStatus
+----------
+
+**Endpoint**: /api/v0/host/{IP}/status
+
+GET
+```
+Retrieve a specific hosts status.
+
+**Query Parameters**
+ * *raw*:
+
+   * **Examples**: ``true``, ``false``, ``True``, ``False``, ``0``, ``1``
+   * **Optional**: Yes
+   * **Description**: If set to true only the status structure from the container manager will be returned
+
+.. code-block:: javascript
+
+  {
+      "type":               string, // type of status
+      "host":               dict,   // status elements from the Host instance
+      "container_manager":  dict,   // status elements reported from the Container Manager
+  }
+
+
+Example: Default
+~~~~~~~~~~~~~~~~
+
+.. code-block:: javascript
+
+  {
+      "type": "host_only",
+      "host": {
+          "last_check": "2016-07-29T19:54:57.204671",
+          "status": "active",
+      },
+      "container_manager": {...}
+  }
+
+
+Example: Raw
+~~~~~~~~~~~~
+
+This example is partially what would be returned from a kubernetes type cluster.
+
+  .. code-block:: javascript
+
+    {
+        "status": {
+            "capacity": {
+              "cpu": "1",
+              "memory": "500680Ki",
+              "pods": "110"
+            },
+            "allocatable": {
+              "cpu": "1",
+              "memory": "500680Ki",
+              "pods": "110"
+            },
+            ...
+        }
+    }
+
 
 Hosts
 -----

--- a/features/hosts/retrieve.feature
+++ b/features/hosts/retrieve.feature
@@ -52,3 +52,22 @@ Feature: Retrieving Hosts
      when we get host credentials for 192.168.152.110
      then commissaire will allow access
      and commissaire will return the host credentials
+
+  @anonymous
+  @hoststatus
+  Scenario: Retrieve existing host status status without authentication
+     Given we are anonymous
+       and a host already exists at 192.168.152.110
+      when we get host status for 192.168.152.110
+      then commissaire will deny access
+
+  @hoststatus
+  Scenario: Retrieve existing host status with authentication
+     Given we have a valid username and password
+       and a host already exists at 192.168.152.110
+       and we have a cluster named honeynut
+       and we add host 192.168.152.110 to the cluster honeynut
+      when we get host status for 192.168.152.110
+      then commissaire will allow access
+      and commissaire will note success
+      and commissaire will return the host status

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -59,6 +59,7 @@ def impl(context, host, cluster):
 
 
 @when('we add host {host} to the cluster {cluster}')
+@given('we add host {host} to the cluster {cluster}')
 def impl(context, host, cluster):
     context.cluster = cluster
     context.request = requests.put(

--- a/features/steps/hosts.py
+++ b/features/steps/hosts.py
@@ -41,6 +41,7 @@ def impl(context, host):
         '/commissaire/hosts/{0}'.format(host),
         json.dumps(data))
 
+
 @given('we have a host at {host}')
 def impl(context, host):
     data = dict(context.HOST_DATA)
@@ -65,6 +66,14 @@ def impl(context):
     context.request = requests.get(
         context.SERVER + '/api/v0/hosts',
         auth=(context.username, context.password))
+
+
+@when('we get host status for {host}')
+def impl(context, host):
+    context.host = host
+    context.request = requests.get(
+        context.SERVER + '/api/v0/host/{0}/status'.format(context.host),
+        auth=context.auth)
 
 
 @when('we {operation} the host {host}')
@@ -92,6 +101,14 @@ def impl(context, host):
     context.request = requests.get(
         context.SERVER + '/api/v0/host/{0}/creds'.format(context.host),
         auth=context.auth)
+
+
+@then('commissaire will return the host status')
+def impl(context):
+    data = context.request.json()
+    assert 'type' in data.keys()
+    assert 'host' in data.keys()
+    assert 'container_manager' in data.keys()
 
 
 @then('commissaire will return the host credentials')

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -106,6 +106,23 @@ class ContainerManager(ContainerManagerBase):
             return True
         return False
 
+    def get_host_status(self, address, raw=False):
+        """
+        Returns the node status.
+
+        :param address: The address of the host to check.
+        :type address: str
+        :param raw: If the result should be limited to its own status.
+        :type raw: bool
+        :returns: The response back from kubernetes.
+        :rtype: requests.Response
+        """
+        part = '/nodes/{0}'.format(address)
+        resp = self._get(part)
+        data = resp.json()
+        if raw:
+            data = data['status']
+        return (resp.status_code, data)
 
 #: Friendly name for the class
 KubeContainerManager = ContainerManager

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -155,6 +155,23 @@ class Host(Model):
     _primary_key = 'address'
 
 
+class HostStatus(Model):
+    """
+    Representation of Host status.
+    """
+    _json_type = dict
+    _attribute_map = {
+        'type': {'type': basestring},
+        'host': {'type': dict},
+        'container_manager': {'type: dict'},
+    }
+    _attribute_defaults = {
+        'type': '',
+        'host': {},
+        'container_manager': {}
+    }
+
+
 class Hosts(Model):
     """
     Representation of a group of one or more Hosts.

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -36,7 +36,8 @@ from commissaire.handlers.clusters import (
     ClusterDeployResource, ClusterRestartResource,
     ClusterUpgradeResource)
 from commissaire.handlers.hosts import (
-    HostCredsResource, HostsResource, HostResource, ImplicitHostResource)
+    HostCredsResource, HostStatusResource, HostsResource,
+    HostResource, ImplicitHostResource)
 from commissaire.handlers.status import StatusResource
 from commissaire.middleware import JSONify
 from commissaire.ssl_adapter import ClientCertBuiltinSSLAdapter
@@ -87,6 +88,7 @@ def create_app(
     app.add_route('/api/v0/host', ImplicitHostResource())
     app.add_route('/api/v0/host/{address}', HostResource())
     app.add_route('/api/v0/host/{address}/creds', HostCredsResource())
+    app.add_route('/api/v0/host/{address}/status', HostStatusResource())
     app.add_route('/api/v0/hosts', HostsResource())
     return app
 

--- a/test/constants.py
+++ b/test/constants.py
@@ -20,7 +20,8 @@ import copy
 import json
 
 from commissaire.handlers.models import (
-    Hosts, Host, Cluster, ClusterRestart, ClusterUpgrade, ClusterDeploy)
+    Hosts, Host, HostStatus, Cluster, ClusterRestart,
+    ClusterUpgrade, ClusterDeploy)
 
 
 def make_new(instance):
@@ -38,11 +39,18 @@ HOST_JSON = (
     ' "last_check": "2015-12-17T15:48:18.710454"}')
 #: Credential JSON for tests
 HOST_CREDS_JSON = '{"remote_user": "root", "ssh_priv_key": "dGVzdAo="}'
+#: HostStatus JSON for tests
+HOST_STATUS_JSON = (
+    '{"type": "host_only", "container_manager": {}, "commissaire": '
+    '{"status": "available", "last_check": "2016-07-29T20:39:50.529454"}}')
 #: Host model for most tests
 HOST = Host.new(
     ssh_priv_key='dGVzdAo=',
     remote_user='root',
     **json.loads(HOST_JSON))
+#: HostStatus model for most tests
+HOST_STATUS = HostStatus.new(
+    **json.loads(HOST_STATUS_JSON))
 #: Hosts model for most tests
 HOSTS = Hosts.new(
     hosts=[HOST]


### PR DESCRIPTION
The endpoint is found at ``/api/v0/host/{IP}/status`` and takes an optional
parameter named ``raw``. If ``raw`` is set to true only the result from the
container manager is returned. If raw is false or unset a ``HostStatus``
result (which includes the container manager result) is returned.