### PR TITLE
[merged] bug: Bootstrapping no longer overwrites nodes into host_only status.

### DIFF
--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -122,13 +122,15 @@ def investigator(queue, config, run_once=False):
                 break
             continue
 
-        host.status = cluster_type = C.CLUSTER_TYPE_HOST
         try:
             cluster = util.cluster_for_host(address, store_manager)
             cluster_type = cluster.type
-        except KeyError:
-            # Not part of a cluster
-            pass
+        except KeyError as ke:
+            logger.debug(
+                '{0} not part of a cluster. Assuming {1}. "{2}"'.format(
+                    host.address, C.CLUSTER_TYPE_HOST, ke))
+            # Not part of a cluster. Assume host_only
+            cluster_type = C.CLUSTER_TYPE_HOST
 
         # Verify association with the container manager
         if cluster_type == C.CLUSTER_TYPE_KUBERNETES:


### PR DESCRIPTION
The investigator job was wrongly overwriting the host.status with the
a static cluster type of host_only.

Resolves #179.