### PR TITLE
Kubernetes auth plugin

### DIFF
--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -85,6 +85,25 @@ Name Required Description
 cn   No       Common name which must match on the client certificate
 ==== ======== ======================================================
 
+commissaire.authentication.kubeauth
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enables `Bearer Token Authentication <https://tools.ietf.org/html/rfc6750#section-2.1>`_
+which comes from Kubernetes.
+
+
+Arguments
+`````````
+======== ======== =========================================================
+Name     Required Description
+======== ======== =========================================================
+resource No       Kubernetes resource used to check authentication against.
+======== ======== =========================================================
+
+.. note::
+
+   If resource is not provided it will default to ``/serviceaccounts``
+
+
 Using an Authentication Plugin
 ------------------------------
 

--- a/src/commissaire/authentication/kubeauth.py
+++ b/src/commissaire/authentication/kubeauth.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import cherrypy
+import falcon
+
+from commissaire.authentication import Authenticator
+
+
+class KubernetesAuth(Authenticator):
+    """
+    Kubernetes auth implementation of an authenticator.
+    """
+
+    def __init__(self, resource='/serviceaccounts'):
+        """
+        Creates an instance of the KubernetesAuth authenticator.
+
+        :param resource: The Kubernetes resource to check against for auth.
+        :type resource: str
+        :raises: IndexError
+        """
+        try:
+            self.resource_check = resource
+            store_manager = cherrypy.engine.publish('get-store-manager')[0]
+            self.logger.debug('{}'.format(store_manager))
+            self._kubernetes = store_manager.list_container_managers(
+                'kubernetes')[0]
+        except IndexError as error:
+            self.logger.fatal(
+                'Unable to get the container manager for Kubernetes. Ensure '
+                'that a store handler has been configured for kubernetes. '
+                'Error: {0}: {1}'.format(type(error), error))
+            raise error
+
+    def _decode_bearer_auth(self, req):
+        """
+        Decodes basic auth from the header.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :returns: token or None if empty.
+        :rtype: str
+        """
+        self.logger.debug('header: {}'.format(req.auth))
+        if req.auth is not None:
+            if req.auth.lower().startswith('bearer '):
+                decoded = req.auth[7:]
+                self.logger.debug('Token given: {0}'.format(decoded))
+                return decoded
+            else:
+                self.logger.debug(
+                    'Did not find bearer in the Authorization '
+                    'header from {0}.'.format(req.remote_addr))
+        # Default meaning no user or password
+        self.logger.debug('Authentication for {0} failed.'.format(
+            req.remote_addr))
+        return None
+
+    def authenticate(self, req, resp):
+        """
+        Implements the authentication logic.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :raises: falcon.HTTPForbidden
+        """
+        token = self._decode_bearer_auth(req)
+        if token is not None:
+            self.logger.debug('Token found: {0}'.format(token))
+            try:
+                # NOTE: We are assuming that if the user has access to
+                # the resource they should be granted access to commissaire
+                self.logger.debug('Checking against {0}.'.format(
+                    self.resource_check))
+                resp = self._kubernetes._get(self.resource_check)
+                self.logger.debug('Kubernetes response: {0}'.format(
+                    resp.json()))
+                # If we get a 200 then the user is valid. Anything else is
+                # a failure
+                if resp.status_code == 200:
+                    self.logger.info(
+                        'Accepted Kubernetes token for {0}'.format(
+                            req.remote_addr))
+                    return
+                self.logger.debug('Rejecting Kubernetes token for {0}'.format(
+                    req.remote_addr))
+            except Exception as error:
+                self.logger.warn(
+                    'Encountered {0} while attempting to '
+                    'authenticate. {1}'.format(type(error), error))
+                raise error
+
+        # Forbid by default
+        raise falcon.HTTPForbidden('Forbidden', 'Forbidden')
+
+
+AuthenticationPlugin = KubernetesAuth

--- a/test/test_authenticator_kubeuath.py
+++ b/test/test_authenticator_kubeuath.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire.authentication.kubeauth module.
+"""
+
+import etcd
+import falcon
+import mock
+
+from . import TestCase, get_fixture_file_path
+from falcon.testing.helpers import create_environ
+from commissaire.authentication import kubeauth
+from commissaire.store.storehandlermanager import StoreHandlerManager
+
+
+class Test_KubernetesAuth(TestCase):
+    """
+    Tests for the KubernetesAuth class.
+    """
+
+    def setUp(self):
+        """
+        Sets up a fresh instance of the class before each run.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            self._container_mgr = mock.MagicMock(
+                'commissaire.store.kubestorehandler.KubernetesStoreHandler')
+            _store_mgr = mock.MagicMock(list_container_managers=lambda s: self._container_mgr)
+            _publish.return_value = [_store_mgr]
+
+            self.kubernetes_auth = kubeauth.KubernetesAuth()
+
+    def test_decode_bearer_auth_with_header(self):
+        """
+        Verify decoding returns a token given the proper header no matter the case of bearer.
+        """
+        bearer = list('bearer')
+        for x in range(0, 5):
+            headers = {'Authorization': '{0} 123'.format(''.join(bearer))}
+            req = falcon.Request(
+                create_environ(headers=headers))
+            self.assertEquals(
+                '123',
+                self.kubernetes_auth._decode_bearer_auth(req))
+            # Update the next letter to be capitalized
+            bearer[x] = bearer[x].capitalize()
+
+    def test_decode_bearer_auth_with_no_header(self):
+        """
+        Verify returns no user with no authorization header.
+        """
+        req = falcon.Request(create_environ(headers={}))
+        self.assertEquals(
+            None,
+            self.kubernetes_auth._decode_bearer_auth(req))
+
+    def test_authenticate_with_header(self):
+        """
+        Verify authenticate uses the submitted token and succeeds with the header.
+        """
+        self._container_mgr.__getitem__()._get = mock.MagicMock(
+            return_value=mock.MagicMock(status_code=200))
+        req = falcon.Request(create_environ(headers={'Authorization': 'Bearer 123'}))
+        resp = falcon.Response()
+        self.kubernetes_auth.authenticate(req, resp)
+        self.assertEquals('200 OK', resp.status)
+
+    def test_authenticate_with_header(self):
+        """
+        Verify authenticate uses the submitted token and forbids without the header.
+        """
+        self._container_mgr.__getitem__()._get = mock.MagicMock(
+            return_value=mock.MagicMock(status_code=409))
+        req = falcon.Request(create_environ(headers={}))
+        resp = falcon.Response()
+        self.assertRaises(
+            falcon.errors.HTTPForbidden,
+            self.kubernetes_auth.authenticate,
+            req,
+            resp)


### PR DESCRIPTION
This plugin forwards the Bearer token through to an OpenShift or Kubernetes resource. If access is granted to that resource then access is also granted to Commisaire.
