### PR TITLE
test: Moved to tox for cross CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: python
 python:
   - "2.7"
-#  - "3.3"
 install:
-  - "pip install -r requirements.txt"
-  - "pip install -r test-requirements.txt"
-  - "pip install importlib"
-  - "pip install -e ."
+  - "pip install tox"
   - "curl -L  https://github.com/coreos/etcd/releases/download/v2.3.3/etcd-v2.3.3-linux-amd64.tar.gz -o etcd-v2.3.3-linux-amd64.tar.gz && tar xvzf etcd-v2.3.3-linux-amd64.tar.gz"
 script:
-  - "flake8 src/"
-  - "python setup.py nosetests"
-  - "PYTHONPATH=$PYTHONPATH:`pwd`/src/commissaire PATH=$PATH:`pwd`/etcd-v2.3.3-linux-amd64 behave -D start-etcd=true -D start-server=true features/"
+  - "tox -v -e py27"
+  - "PATH=$PATH:`pwd`/etcd-v2.3.3-linux-amd64 tox -v -e e2e"
 notifications:
   email: false
   # This is Colin's instance of Homu, in the future

--- a/doc/examples/run_unittest_example.rst
+++ b/doc/examples/run_unittest_example.rst
@@ -1,5 +1,4 @@
 .. code-block:: shell
 
-   (virtualenv)$ pip install -r test-requirements.txt
+   $ tox
    ...
-   (virtualenv)$ python setup.py nosetests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+tox
 behave
 requests
 nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27
+
+[testenv]
+recreate = true
+deps =
+    -rrequirements.txt
+    -rtest-requirements.txt
+
+[testenv:py27]
+commands =
+    flake8 src/
+    nosetests
+
+[testenv:e2e]
+commands =
+    behave -D start-etcd=true -D start-server=true features/


### PR DESCRIPTION
This change moves our testing to use [tox](https://testrun.org/tox/latest/) instead of "hard coding" the work in travis. This should allow multiple CI systems to easily run the same commands without needing to copy/paste between systems. There still may be some translation (example: we have to download and etcd with wget on Travis while on a Jenkins instance we can probably dnf install) but this still should make it all much simpler.

Thanks to @cgwalters for bringing up the idea of using a central CI script.