### PR TITLE
Delay saving host data until after bootstrapping

### DIFF
--- a/conf/commissaire.conf
+++ b/conf/commissaire.conf
@@ -1,8 +1,22 @@
 {
     "listen-interface": "127.0.0.1",
     "listen-port": 8000,
-    "etcd-uri": "http://192.168.152.101:2379",
-    "kube-uri": "http://192.168.152.102:8080",
+    "register-store-handler": [
+        {
+            "name": "commissaire.store.etcdstorehandler",
+            "protocol": "http",
+            "host": "192.168.152.101",
+            "port": 2379,
+            "models": ["*"]
+        },
+        {
+            "name": "commissaire.store.kubestorehandler",
+            "protocol": "http",
+            "host": "192.168.152.102",
+            "port": 8080,
+            "models": []
+        }
+    ],
     "authentication-plugin": {
         "name": "commissaire.authentication.httpbasicauth",
         "users": {

--- a/features/environment.py
+++ b/features/environment.py
@@ -117,6 +117,10 @@ def stop_server(context, attr):
         server.wait()
 
 def before_tag(context, tag):
+    if tag == "slow":
+        if not context.config.userdata.get('use-vagrant', None):
+            context.scenario.skip(reason='requires vagrant environment')
+
     if tag == "clientcert":
         verifyfile = os.path.join(context.CERT_DIR, "ca.pem")
         certfile = os.path.join(context.CERT_DIR, "server.pem")

--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -203,6 +203,14 @@ class HostResource(Resource):
         :param address: The address of the Host being requested.
         :type address: str
         """
+        # If the host is still bootstrapping, the store handler
+        # won't find it yet.  So respond with a fake host status.
+        if cherrypy.engine.publish('investigator-is-pending', address)[0]:
+            host = Host.new(address=address, status='investigating')
+            resp.status = falcon.HTTP_200
+            req.context['model'] = host
+            return
+
         # TODO: Verify input
         try:
             store_manager = cherrypy.engine.publish('get-store-manager')[0]

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -241,7 +241,7 @@ def etcd_host_create(address, ssh_priv_key, remote_user, cluster_name=None):
         etcd_cluster_add_host(cluster_name, address)
 
     manager_clone = store_manager.clone()
-    job_request = (manager_clone, host_creation, ssh_priv_key, remote_user)
+    job_request = (manager_clone, host_creation)
     INVESTIGATE_QUEUE.put(job_request)
 
     return (falcon.HTTP_201, new_host)

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -44,12 +44,12 @@ def investigator(queue, run_once=False):
     while True:
         # Statuses follow:
         # http://commissaire.readthedocs.org/en/latest/enums.html#host-statuses
-        store_manager, to_investigate, ssh_priv_key, remote_user = queue.get()
+        store_manager, to_investigate = queue.get()
         address = to_investigate['address']
+        remote_user = to_investigate['remote_user']
         logger.info('{0} is now in investigating.'.format(address))
         logger.debug(
-            'Investigation details: key={0}, data={1}, remote_user={2}'.format(
-                to_investigate, ssh_priv_key, remote_user))
+            'Investigation details: {0}'.format(to_investigate))
 
         transport = ansibleapi.Transport(remote_user)
 

--- a/src/commissaire/queues.py
+++ b/src/commissaire/queues.py
@@ -140,7 +140,7 @@ INVESTIGATE_QUEUE = MPQueue()
 """
 Input queue for the investigator thread(s).
 
-:expects: (store_manager, address, ssh_priv_key, remote_user)
+:expects: (store_manager, host_dictionary)
 :type: multiprocessing.queues.Queues
 """
 

--- a/src/commissaire/queues.py
+++ b/src/commissaire/queues.py
@@ -136,15 +136,6 @@ class IterableModelQueue(MPQueue):
         raise Exception('No model in {0}'.format(item))
 
 
-INVESTIGATE_QUEUE = MPQueue()
-"""
-Input queue for the investigator thread(s).
-
-:expects: (store_manager, host_dictionary)
-:type: multiprocessing.queues.Queues
-"""
-
-
 WATCHER_QUEUE = IterableModelQueue()
 """
 Input queue for watcher thread(s).

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -31,7 +31,6 @@ from ansible.plugins.callback import default
 from ansible.utils.display import Display
 
 from commissaire import constants as C
-from commissaire.handlers import util
 from commissaire.store.etcdstorehandler import EtcdStoreHandler
 from commissaire.store.kubestorehandler import KubernetesStoreHandler
 
@@ -411,12 +410,14 @@ class Transport:
 
         return kube_config
 
-    def bootstrap(self, ip, key_file, store_manager, oscmd):
+    def bootstrap(self, ip, cluster_type, key_file, store_manager, oscmd):
         """
         Bootstraps a host via ansible.
 
-        :param ip: IP address to reboot.
+        :param ip: IP address to bootstrap.
         :type ip: str
+        :param cluster_type: The type of cluster the host is to be added to
+        :type cluster_type: str
         :param key_file: Full path to the file holding the private SSH key.
         :type key_file: str
         :param store_manager: Remote object for remote stores
@@ -428,13 +429,6 @@ class Transport:
         """
         self.logger.debug('Using {0} as the oscmd class for {1}'.format(
             oscmd.os_type, ip))
-
-        cluster_type = C.CLUSTER_TYPE_HOST
-        try:
-            cluster_type = util.cluster_for_host(ip, store_manager).type
-        except KeyError:
-            # Not part of a cluster
-            pass
 
         etcd_config = self._get_etcd_config(store_manager)
         kube_config = self._get_kube_config(store_manager)

--- a/test/constants.py
+++ b/test/constants.py
@@ -37,6 +37,18 @@ HOST_JSON = (
     ' "status": "available", "os": "atomic",'
     ' "cpus": 2, "memory": 11989228, "space": 487652,'
     ' "last_check": "2015-12-17T15:48:18.710454"}')
+#: Response JSON for a newly created host
+INITIAL_HOST_JSON = (
+    '{"address": "10.2.0.2",'
+    ' "status": "investigating", "os": "",'
+    ' "cpus": 0, "memory": 0, "space": 0,'
+    ' "last_check": ""}')
+#: Response JSON for a newly created implicit host (no address given)
+INITIAL_IMPLICIT_HOST_JSON = (
+    '{"address": "127.0.0.1",'
+    ' "status": "investigating", "os": "",'
+    ' "cpus": 0, "memory": 0, "space": 0,'
+    ' "last_check": ""}')
 #: Credential JSON for tests
 HOST_CREDS_JSON = '{"remote_user": "root", "ssh_priv_key": "dGVzdAo="}'
 #: HostStatus JSON for tests

--- a/test/test_cherrypy_plugins_investigator.py
+++ b/test/test_cherrypy_plugins_investigator.py
@@ -28,7 +28,9 @@ class Test_InvestigatorPlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('investigator-is-alive', 'investigator-submit')
+    topics = ('investigator-is-alive',
+              'investigator-is-pending',
+              'investigator-submit')
 
     def before(self):
         """

--- a/test/test_cherrypy_plugins_investigator.py
+++ b/test/test_cherrypy_plugins_investigator.py
@@ -28,7 +28,7 @@ class Test_InvestigatorPlugin(TestCase):
     """
 
     #: Topics that should be registered
-    topics = ('investigator-is-alive', )
+    topics = ('investigator-is-alive', 'investigator-submit')
 
     def before(self):
         """
@@ -51,16 +51,17 @@ class Test_InvestigatorPlugin(TestCase):
         # The processes should not have started yet
         self.assertFalse(self.plugin.is_alive())
 
-        # There should be bus subscribed topics
-        for topic in self.topics:
-            self.bus.subscribe.assert_any_call(topic, mock.ANY)
-
     def test_investigator_plugin_start(self):
         """
         Verify start() starts the background process.
         """
         self.assertFalse(self.plugin.is_alive())
         self.plugin.start()
+
+        # There should be bus subscribed topics
+        for topic in self.topics:
+            self.bus.subscribe.assert_any_call(topic, mock.ANY)
+
         self.assertTrue(self.plugin.is_alive())
         self.plugin.stop()
 

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -61,13 +61,14 @@ class Test_JobsInvestigator(TestCase):
 
             to_investigate = {
                 'address': '10.0.0.2',
+                'ssh_priv_key': 'dGVzdAo=',
+                'remote_user': 'root'
             }
-            ssh_priv_key = 'dGVzdAo='
 
             manager = MagicMock(StoreHandlerManager)
             manager.get.return_value = Host(**json.loads(self.etcd_host))
 
-            q.put_nowait((manager, to_investigate, ssh_priv_key, 'root'))
+            q.put_nowait((manager, to_investigate))
             investigator(q, run_once=True)
 
             self.assertEquals(1, manager.get.call_count)

--- a/test/test_transport_ansibleapi.py
+++ b/test/test_transport_ansibleapi.py
@@ -139,7 +139,8 @@ class Test_Transport(TestCase):
             oscmd = MagicMock(OSCmdBase)
 
             result, facts = transport.bootstrap(
-                '10.2.0.2', 'test/fake_key', MagicMock(), oscmd)
+                '10.2.0.2', 'host_only',
+                'test/fake_key', MagicMock(), oscmd)
             # We should have a successful response
             self.assertEquals(0, result)
             # We should see expected calls
@@ -171,7 +172,8 @@ class Test_Transport(TestCase):
             transport._run = MagicMock()
             transport._run.return_value = (0, {})
             result, facts = transport.bootstrap(
-                '10.2.0.2.', 'test/fake_key', store_manager, oscmd)
+                '10.2.0.2.', 'host_only',
+                'test/fake_key', store_manager, oscmd)
             play_vars = transport._run.call_args[0][4]
             self.assertEqual(
                 play_vars['commissaire_etcd_scheme'], 'https')
@@ -200,7 +202,8 @@ class Test_Transport(TestCase):
             for os_type in available_os_types:
                 oscmd = get_oscmd(os_type)
                 result, facts = transport.bootstrap(
-                    '10.2.0.2.', 'test/fake_key', MagicMock(), oscmd)
+                    '10.2.0.2.', 'host_only',
+                    'test/fake_key', MagicMock(), oscmd)
                 play_vars = transport._run.call_args[0][4]
                 command = play_vars['commissaire_enable_pkg_repos']
                 if os_type in needs_enable_repos:


### PR DESCRIPTION
Resolves #177 

Couple subtle semantic changes:

 - A newly created host is not added to a cluster until *after* its bootstrapping successfully completes.  Otherwise if a cluster operation were to be started in the interim, the new host may not yet be in a usable state and the cluster operation would fail.

 - We lose some granularity in host status; namely, the `"bootstrapping"` status is no longer observable since host data is not saved until bootstapping is finished.