### PR TITLE
Fix nuisance error when terminating investigator thread.

### DIFF
--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -25,6 +25,13 @@ from threading import Thread
 from commissaire.jobs.investigator import investigator
 
 
+class Sentinel(object):
+    """
+    Passed over a multiprocessing.Queue as a loop terminator.
+    """
+    pass
+
+
 class InvestigatorPlugin(plugins.SimplePlugin):
 
     def __init__(self, bus):
@@ -52,7 +59,7 @@ class InvestigatorPlugin(plugins.SimplePlugin):
             args=(self.request_queue, self.response_queue))
         self.response_thread = None
         self.pending_requests = {}  # host address -> closure
-        self.sentinel = object()    # stops the response thread
+        self.sentinel = Sentinel()  # stops the response thread
 
     def __response_thread(self):
         """
@@ -64,7 +71,7 @@ class InvestigatorPlugin(plugins.SimplePlugin):
         while True:
             response = self.response_queue.get()
             assert os.getpid() == self.main_pid
-            if response is self.sentinel:
+            if isinstance(response, Sentinel):
                 break
             host, exception = response
             try:


### PR DESCRIPTION
A special sentinel object is passed over a `multiprocessing.Queue` as a loop terminator for the `InvestigatorPlugin`'s response thread. However the sentinel is pickled, so it's a different instance when popped off the queue and we were comparing object IDs.

Fixes https://github.com/projectatomic/commissaire/issues/188