### PR TITLE
Support for flannel in server mode via networks endpoint.

### DIFF
--- a/doc/apidoc/commissaire.handlers.networks.rst
+++ b/doc/apidoc/commissaire.handlers.networks.rst
@@ -1,0 +1,7 @@
+commissaire.handlers.networks module
+====================================
+
+.. automodule:: commissaire.handlers.networks
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.handlers.rst
+++ b/doc/apidoc/commissaire.handlers.rst
@@ -9,6 +9,7 @@ Submodules
    commissaire.handlers.clusters
    commissaire.handlers.hosts
    commissaire.handlers.models
+   commissaire.handlers.networks
    commissaire.handlers.status
    commissaire.handlers.util
 

--- a/doc/endpoints.rst
+++ b/doc/endpoints.rst
@@ -50,6 +50,7 @@ Creates a new cluster.
 
     {
         "type": enum(string), // The cluster type
+        "network": string     // The name of the network
     }
 
 .. note::
@@ -63,7 +64,8 @@ Example
 .. code-block:: javascript
 
    {
-       "type": "kubernetes"
+       "type": "kubernetes",
+       "network": "default"
    }
 
 
@@ -509,6 +511,103 @@ Example
            "last_check": "2015-12-17T15:48:30.401090"
        }
    ]
+
+
+.. _networks_op:
+
+
+Networks
+--------
+**Endpoint**: /api/v0/networks/
+
+GET
+```
+Retrieve a list of all networks.
+
+.. code-block:: javascript
+
+   [
+       string,...
+   ]
+
+
+Example
+~~~~~~~
+
+.. code-block:: javascript
+
+   [
+      "mynetwork",
+   ]
+
+
+.. _network_op:
+
+Network
+-------
+
+**Endpoint**: /api/v0/network/{name}
+
+GET
+```
+Retrieve a specific network record.
+
+.. code-block:: javascript
+
+  {
+      "name": string,        // The name of the network
+      "type":  enum(string), // The type of the network
+      "options": dict        // Options to explain a network
+  }
+
+.. note::
+  See :ref:`network-types` for a list and description of network types.
+
+Example
+~~~~~~~
+
+.. code-block:: javascript
+
+  {
+      "name": "mynetwork",
+      "type": "flannel_server",
+      "options": {
+          "address": "192.168.152.101:8080"
+      },
+  }
+
+PUT
+```
+Creates a new network record.
+
+
+.. code-block:: javascript
+
+  {
+      "type":  enum(string), // The type of the network
+      "options": dict        // Options to explain a network
+  }
+
+.. note::
+  See :ref:`network-types` for a list and description of network types.
+
+
+Example
+~~~~~~~
+
+.. code-block:: javascript
+
+  {
+      "type": "flannel_server",
+      "options": {
+          "address": "192.168.152.101:8080"
+      },
+  }
+
+DELETE
+``````
+Deletes a network record.
+
 
 
 Status

--- a/doc/enums.rst
+++ b/doc/enums.rst
@@ -12,6 +12,11 @@ OS's
 * **fedora**: https://getfedora.org/
 
 
+.. _network-types:
+
+* **flannel_etcd**: Uses the configured etcd store handler for it's network configuration
+* **flanneld_service**:  Uses flannel in client/server mode. Requires options to have ``address`` of ``host:port``.
+
 
 Statuses
 --------

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -30,7 +30,9 @@ def impl(context, cluster):
     request = requests.put(
         context.SERVER + '/api/v0/cluster/{0}'.format(cluster),
         auth=(VALID_USERNAME, VALID_PASSWORD),
-        data=json.dumps({'type': C.CLUSTER_TYPE_HOST}))
+        data=json.dumps({
+            'type': C.CLUSTER_TYPE_HOST,
+            'network': 'default'}))
     assert_status_code(request.status_code, 201)
 
 
@@ -144,17 +146,17 @@ def impl(context):
 
 @then('the provided cluster status is {status}')
 def impl(context, status):
-    json = context.request.json()
-    assert json['status'] == status, \
-        'Expected status {0}, got {1}'.format(status, json['status'])
+    json_data = context.request.json()
+    assert json_data['status'] == status, \
+        'Expected status {0}, got {1}'.format(status, json_data['status'])
 
 
 @then('the provided cluster {what} hosts is {expected}')
 def impl(context, what, expected):
-    json = context.request.json()
-    assert json['hosts'][what] == int(expected), \
+    json_data = context.request.json()
+    assert json_data['hosts'][what] == int(expected), \
         'Expected {0} {1} hosts, got {2}'.format(
-            expected, what, json['hosts'][what])
+            expected, what, json_data['hosts'][what])
 
 
 @then('the host {host} will be in the cluster {cluster}')
@@ -185,7 +187,7 @@ def impl(context, cluster):
 
 @then('commissaire will provide {async_operation} status')
 def impl(context, async_operation):
-    json = context.request.json()
+    json_data = context.request.json()
     if async_operation == 'upgrade':
         expected_keys = set(('name', 'status', 'upgraded',
                              'in_process', 'started_at', 'finished_at'))
@@ -195,14 +197,14 @@ def impl(context, async_operation):
     elif async_operation == 'deployment':
         expected_keys = set(('name', 'status', 'version', 'deployed',
                              'in_process', 'started_at', 'finished_at'))
-    actual_keys = set(json.keys())
+    actual_keys = set(json_data.keys())
     assert actual_keys == expected_keys, \
-           'Expected keys {0}, got {1}'.format(expected_keys, actual_keys)
+        'Expected keys {0}, got {1}'.format(expected_keys, actual_keys)
 
 
 @then('the provided status is {status}')
 def impl(context, status):
-    json = context.request.json()
-    actual_status = json.get('status')
+    json_data = context.request.json()
+    actual_status = json_data.get('status')
     assert actual_status == status, \
-           'Expected status {0}, got {1}'.format(status, actual_status)
+        'Expected status {0}, got {1}'.format(status, actual_status)

--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -115,7 +115,7 @@ class InvestigatorPlugin(plugins.SimplePlugin):
             self.process.terminate()
             self.process.join()
 
-    def submit(self, store_manager, host, cluster_type, callback=None):
+    def submit(self, store_manager, host, cluster, callback=None):
         """
         Submits a new request to the investigator process.  If a callback
         was given, it will be invoked when the request has finished.  The
@@ -127,8 +127,8 @@ class InvestigatorPlugin(plugins.SimplePlugin):
                              StoreHandlerManager
         :param host: A Host model representing the host to investigate.
         :type host: commissaire.handlers.models.Host
-        :param cluster_type: The type of cluster the host is to be added to
-        :type cluster_type: str
+        :param cluster: The type of cluster the host is to be added to
+        :type cluster: commissaire.handlers.models.Cluster or None
         :param callback: A callable to invoke when the request is complete.
         :type callback: callable or None
         """
@@ -138,7 +138,11 @@ class InvestigatorPlugin(plugins.SimplePlugin):
         closure = invoke_callback if callback is not None else None
         self.pending_requests[host.address] = closure
         manager_clone = store_manager.clone()
-        job_request = (manager_clone, host.__dict__, cluster_type)
+
+        # Since cluster might be None we need to check for __dict__
+        cluster_dict = getattr(cluster, '__dict__', None)
+
+        job_request = (manager_clone, host.__dict__, cluster_dict)
         self.request_queue.put(job_request)
 
     def is_alive(self):

--- a/src/commissaire/cherrypy_plugins/investigator.py
+++ b/src/commissaire/cherrypy_plugins/investigator.py
@@ -127,7 +127,7 @@ class InvestigatorPlugin(plugins.SimplePlugin):
                              StoreHandlerManager
         :param host: A Host model representing the host to investigate.
         :type host: commissaire.handlers.models.Host
-        :param cluster: The type of cluster the host is to be added to
+        :param cluster: Cluster model instance the host is to be added to
         :type cluster: commissaire.handlers.models.Cluster or None
         :param callback: A callable to invoke when the request is complete.
         :type callback: callable or None

--- a/src/commissaire/constants.py
+++ b/src/commissaire/constants.py
@@ -23,6 +23,19 @@ CLUSTER_TYPE_KUBERNETES = 'kubernetes'
 #: Cluster type to use if none is specified
 CLUSTER_TYPE_DEFAULT = CLUSTER_TYPE_KUBERNETES
 
+#: Flannel using etcd as it's configuration end
+NETWORK_TYPE_FLANNEL_ETCD = 'flannel_etcd'
+#: Flannel using a flannel server as it's configuration end
+NETWORK_TYPE_FLANNEL_SERVER = 'flannel_server'
+#: Network type to use if none is specified
+NETWORK_TYPE_DEFAULT = NETWORK_TYPE_FLANNEL_ETCD
+
+#: Default network if non is provided
+DEFAULT_CLUSTER_NETWORK_JSON = {
+    'name': 'default',
+    'type': NETWORK_TYPE_DEFAULT
+}
+
 # Default etcd configuration
 DEFAULT_ETCD_STORE_HANDLER = {
     'name': 'commissaire.store.etcdstorehandler',

--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,5 +1,22 @@
+{%- set OPTIONS="" %}
+
+{%- if commissaire_etcd_scheme is defined %}
 FLANNEL_ETCD="{{ commissaire_etcd_scheme }}://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
+{%- elif commissaire_flanneld_server is defined %}
+{#- commissaire_flanneld_server indicates a client/server model #}
+{%- set OPTIONS=OPTIONS ~ "--remote=" ~ commissaire_flanneld_server ~ " " %}
+{%- endif %}
+{#- commissaire_flanneld_etcd_client_keypath indicates the use of TLS for either client/server or etcd #}
 {%- if commissaire_etcd_client_key_path is defined %}
-FLANNEL_OPTIONS="-remote-keyfile={{ commissaire_etcd_client_key_path }} -remote-certfile={{ commissaire_etcd_client_cert_path }} -etcd-cafile={{ commissaire_etcd_ca_path }}"{% elif commissaire_etcd_ca_path is defined %}
-FLANNEL_OPTIONS="-etcd-cafile={{ commissaire_etcd_ca_path }}"{% endif %}
+    {%- set OPTIONS=OPTIONS ~ "--remote-keyfile=" ~ commissaire_etcd_client_key_path ~ " --remote-certfile=" ~ commissaire_etcd_client_cert_path ~ " " %}
+{%- endif %}
+
+{%- if commissaire_etcd_ca_path is defined %}
+    {%- set OPTIONS=OPTIONS ~ "--etcd-cafile=" ~ commissaire_etcd_ca_path ~ " " %}
+{%- endif %}
+{%- if OPTIONS %}
+
+{#- Set FLANNEL_OPTIONS to OPTIONS with the last character removed #}
+FLANNEL_OPTIONS="{{ OPTIONS[:-1] }}"
+{%- endif %}

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -22,6 +22,37 @@ from commissaire import constants as C
 from commissaire.model import Model
 
 
+class Network(Model):
+    """
+    Representation of a network.
+    """
+    _json_type = dict
+    _attribute_map = {
+        'name': {'type': basestring},
+        'type': {'type': basestring},
+        'options': {'type': dict},
+    }
+    _attribute_defaults = {
+        'name': '',
+        'type': C.NETWORK_TYPE_FLANNEL_ETCD,
+        'options': {},
+    }
+    _primary_key = 'name'
+
+
+class Networks(Model):
+    """
+    Representation of a group of one or more Networks.
+    """
+    _json_type = list
+    _attribute_map = {
+        'networks': {'type': list},
+    }
+    _attribute_defaults = {'networks': []}
+    _list_attr = 'networks'
+    _list_class = Network
+
+
 class Cluster(Model):
     """
     Representation of a Cluster.
@@ -31,12 +62,15 @@ class Cluster(Model):
         'name': {'type': basestring},
         'status': {'type': basestring},
         'type': {'type': basestring},
+        'network': {'type': basestring},
         'hostset': {'type': list},
     }
     _hidden_attributes = ('hostset',)
     _attribute_defaults = {
         'name': '', 'type': C.CLUSTER_TYPE_DEFAULT,
-        'status': '', 'hostset': []}
+        'status': '', 'hostset': [],
+        'network': 'flannel_etcd',
+    }
     _primary_key = 'name'
 
     def __init__(self, **kwargs):

--- a/src/commissaire/handlers/networks.py
+++ b/src/commissaire/handlers/networks.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Network(s) handlers.
+"""
+
+import json
+
+import cherrypy
+import falcon
+
+from commissaire.resource import Resource
+from commissaire.handlers.models import Network, Networks
+
+
+class NetworksResource(Resource):
+    """
+    Resource for working with Networks.
+    """
+
+    def on_get(self, req, resp):
+        """
+        Handles GET requests for Networks.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        """
+
+        try:
+            store_manager = cherrypy.engine.publish('get-store-manager')[0]
+            networks = store_manager.list(Networks(networks=[]))
+            if len(networks.networks) == 0:
+                raise Exception()
+            resp.status = falcon.HTTP_200
+            resp.body = json.dumps([
+                network.name for network in networks.networks])
+        except Exception:
+            self.logger.warn(
+                'Store does not have any networks. Returning [] and 404.')
+            resp.status = falcon.HTTP_404
+            req.context['model'] = None
+            return
+
+
+class NetworkResource(Resource):
+    """
+    Resource for working with a single Network.
+    """
+
+    def on_get(self, req, resp, name):
+        """
+        Handles retrieval of an existing Network.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The friendly name of the network.
+        :type address: str
+        """
+        try:
+            store_manager = cherrypy.engine.publish('get-store-manager')[0]
+            network = store_manager.get(Network.new(name=name))
+            resp.status = falcon.HTTP_200
+            req.context['model'] = network
+        except:
+            resp.status = falcon.HTTP_404
+            return
+
+    def on_put(self, req, resp, name):
+        """
+        Handles the creation of a new Network.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The friendly name of the network.
+        :type address: str
+        """
+        try:
+            req_data = req.stream.read()
+            req_body = json.loads(req_data.decode())
+            network_type = req_body['type']
+            options = req_body.get('options', {})
+        except (KeyError, ValueError):
+            self.logger.info(
+                'Bad client PUT request for network {0}: {1}'.
+                format(name, req_data))
+            resp.status = falcon.HTTP_400
+            return
+
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        network = Network.new(name=name, type=network_type, options=options)
+        self.logger.debug('Saving network: {0}'.format(network.to_json()))
+        store_manager.save(network)
+
+        resp.status = falcon.HTTP_CREATED
+        req.context['model'] = network
+
+    def on_delete(self, req, resp, name):
+        """
+        Handles the Deletion of a Network.
+
+        :param req: Request instance that will be passed through.
+        :type req: falcon.Request
+        :param resp: Response instance that will be passed through.
+        :type resp: falcon.Response
+        :param name: The friendly name of the network.
+        :type address: str
+        """
+        resp.body = '{}'
+        store_manager = cherrypy.engine.publish('get-store-manager')[0]
+        try:
+            store_manager.delete(Network.new(name=name))
+            resp.status = falcon.HTTP_200
+        except Exception as error:
+            self.logger.warn('{}: {}'.format(type(error), error))
+            resp.status = falcon.HTTP_404

--- a/src/commissaire/handlers/util.py
+++ b/src/commissaire/handlers/util.py
@@ -18,8 +18,6 @@ Resource utilities.
 import cherrypy
 import falcon
 
-import commissaire.constants as C
-
 from commissaire.handlers.models import Cluster, Clusters, Host
 
 
@@ -226,9 +224,8 @@ def etcd_host_create(address, ssh_priv_key, remote_user, cluster_name=None):
         cluster = get_cluster_model(cluster_name)
         if cluster is None:
             return (falcon.HTTP_409, None)
-        cluster_type = cluster.type
     else:
-        cluster_type = C.CLUSTER_TYPE_HOST
+        cluster = None
 
     host = Host.new(
         address=address,
@@ -245,6 +242,6 @@ def etcd_host_create(address, ssh_priv_key, remote_user, cluster_name=None):
                 etcd_cluster_add_host(cluster_name, host.address)
 
     cherrypy.engine.publish(
-        'investigator-submit', store_manager, host, cluster_type, callback)
+        'investigator-submit', store_manager, host, cluster, callback)
 
     return (falcon.HTTP_201, host)

--- a/src/commissaire/script.py
+++ b/src/commissaire/script.py
@@ -38,6 +38,7 @@ from commissaire.handlers.clusters import (
 from commissaire.handlers.hosts import (
     HostCredsResource, HostStatusResource, HostsResource,
     HostResource, ImplicitHostResource)
+from commissaire.handlers.networks import (NetworkResource, NetworksResource)
 from commissaire.handlers.status import StatusResource
 from commissaire.middleware import JSONify
 from commissaire.ssl_adapter import ClientCertBuiltinSSLAdapter
@@ -85,6 +86,8 @@ def create_app(
         '/api/v0/cluster/{name}/upgrade',
         ClusterUpgradeResource())
     app.add_route('/api/v0/clusters', ClustersResource())
+    app.add_route('/api/v0/network/{name}', NetworkResource())
+    app.add_route('/api/v0/networks', NetworksResource())
     app.add_route('/api/v0/host', ImplicitHostResource())
     app.add_route('/api/v0/host/{address}', HostResource())
     app.add_route('/api/v0/host/{address}/creds', HostCredsResource())

--- a/src/commissaire/store/etcdstorehandler.py
+++ b/src/commissaire/store/etcdstorehandler.py
@@ -31,6 +31,8 @@ _etcd_mapper = {
     'Clusters': '/clusters/',
     'Host': '/hosts/{0}',
     'Hosts': '/hosts',
+    'Network': '/networks/{0}',
+    'Networks': '/networks',
     'Status': '/status',
 }
 

--- a/src/commissaire/store/kubestorehandler.py
+++ b/src/commissaire/store/kubestorehandler.py
@@ -35,6 +35,8 @@ _model_mapper = {
     'Clusters': '/namespaces/default/',
     'Host': '/nodes/',
     'Hosts': '/nodes/',
+    'Network': '/nodes/',
+    'Networks': '/nodes/',
     'Status': '/namespaces/default/',
 }
 

--- a/test/test_handlers_clusters.py
+++ b/test/test_handlers_clusters.py
@@ -278,15 +278,17 @@ class Test_ClusterResource(TestCase):
                 test_cluster
             )
 
+            test_body = '{"network": "default"}'
+
             body = self.simulate_request(
-                '/api/v0/cluster/development', method='PUT')
+                '/api/v0/cluster/development', method='PUT', body=test_body)
             self.assertEquals(falcon.HTTP_201, self.srmock.status)
             self.assertEquals('{}', body[0])
 
             # Verify with existing cluster
             manager.get.return_value = CLUSTER
             body = self.simulate_request(
-                '/api/v0/cluster/development', method='PUT')
+                '/api/v0/cluster/development', method='PUT', body=test_body)
             self.assertEquals(falcon.HTTP_201, self.srmock.status)
             self.assertEquals('{}', body[0])
 

--- a/test/test_handlers_networks.py
+++ b/test/test_handlers_networks.py
@@ -1,0 +1,291 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire.handlers.networks module.
+"""
+
+import json
+import mock
+
+import etcd
+import falcon
+
+from . import TestCase
+from .constants import *
+from mock import MagicMock
+from commissaire.handlers import networks
+from commissaire.middleware import JSONify
+from commissaire.store.storehandlermanager import StoreHandlerManager
+
+
+class Test_Networks(TestCase):
+    """
+    Tests for the Networks model.
+    """
+
+    def test_networks_creation(self):
+        """
+        Verify Networks model.
+        """
+        # Make sure networks is required
+        self.assertRaises(
+            TypeError,
+            networks.Networks
+        )
+
+        # Make sure an empty Networks is still valid
+        networks_model = networks.Networks(networks=[])
+        self.assertEquals(
+            '[]',
+            networks_model.to_json())
+
+        # Make sure a Network is accepted as expected
+        networks_model = networks.Networks(
+            networks=[networks.Network.new(
+                name='network', type='flannel_etcd', options={})])
+        self.assertEquals(1, len(networks_model.networks))
+        self.assertEquals(type(str()), type(networks_model.to_json()))
+
+        # Make sure other instances are not accepted
+        networks_model = networks.Networks(networks=[object()])
+
+    def test_networks_defaults_values(self):
+        """
+        Verify Networks model fills default values when missing.
+        """
+        model_instance = networks.Networks.new()
+        self.assertEquals(
+            networks.Networks._attribute_defaults['networks'],
+            model_instance.networks)
+
+
+class Test_NetworksResource(TestCase):
+    """
+    Tests for the Networks resource.
+    """
+
+    network_name = u'default'
+
+    def before(self):
+        self.api = falcon.API(middleware=[JSONify()])
+        self.resource = networks.NetworksResource()
+        self.api.add_route('/api/v0/networks', self.resource)
+
+    def test_networks_listing(self):
+        """
+        Verify listing Networks.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            return_value = networks.Networks(
+                networks=[networks.Network.new(name=self.network_name)])
+            manager.list.return_value = return_value
+
+            body = self.simulate_request('/api/v0/networks')
+            self.assertEqual(falcon.HTTP_200, self.srmock.status)
+
+            self.assertEqual(
+                [self.network_name],
+                json.loads(body[0]))
+
+    def test_networks_listing_with_no_networks(self):
+        """
+        Verify listing Networks when no networks exist.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            return_value = networks.Networks(networks=[])
+            manager = mock.MagicMock(StoreHandlerManager)
+            manager.list.return_value = return_value
+            _publish.return_value = [manager]
+
+            body = self.simulate_request('/api/v0/networks')
+            self.assertEqual(self.srmock.status, falcon.HTTP_404)
+            self.assertEqual({}, json.loads(body[0]))
+
+    def test_networks_listing_with_no_etcd_result(self):
+        """
+        Verify listing Networks handles no etcd result properly.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            _publish.return_value = [[[], etcd.EtcdKeyNotFound()]]
+
+            body = self.simulate_request('/api/v0/networks')
+            self.assertEqual(self.srmock.status, falcon.HTTP_404)
+            self.assertEqual('{}', body[0])
+
+
+class Test_Network(TestCase):
+    """
+    Tests for the Network model.
+    """
+
+    def test_network_creation(self):
+        """
+        Verify network model.
+        """
+        # Make sure it requires data
+        self.assertRaises(
+            TypeError,
+            networks.Network)
+
+        # Make sure a Network creates expected results
+        network_model = networks.Network.new(
+            name='network', type='flannel_etcd', options={})
+        self.assertEquals(type(str()), type(network_model.to_json()))
+        self.assertEquals('network', network_model.name)
+        self.assertEquals('flannel_etcd', network_model.type)
+        self.assertEquals({}, network_model.options)
+
+        # Make sure coercion works
+        network_model.name = 1
+        network_model.type = 1
+
+        network_model._coerce()
+
+        # Validate should be happy with the result
+        self.assertIsNone(network_model._validate())
+
+    def test_network_defaults_values(self):
+        """
+        Verify Network model fills default values when missing.
+        """
+        model_instance = networks.Network.new()
+        self.assertEquals(
+            networks.Network._attribute_defaults['name'],
+            model_instance.name)
+        self.assertEquals(
+            networks.Network._attribute_defaults['type'],
+            model_instance.type)
+        self.assertEquals(
+            networks.Network._attribute_defaults['options'],
+            model_instance.options)
+
+        # Set subsets of values.
+        for kwargs in (
+                {'name': 'test'},
+                {'name': 'test', 'type': 'flannel_etcd'},
+                {'name': 'test', 'options': {}},
+                {'type': 'flannel_etcd'},
+                {'type': 'flannel_etcd', 'options': {'address': '192.168.152.110:8080'}},
+                {'options': {'address': '192.168.152.110'}}):
+            model_instance = networks.Network.new(**kwargs)
+            not_done = list(networks.Network._attribute_map.keys())
+            for k, v in kwargs.items():
+                self.assertEquals(v, getattr(model_instance, k))
+                not_done.remove(k)
+            for k in not_done:
+                self.assertEquals(
+                networks.Network._attribute_defaults[k],
+                getattr(model_instance, k))
+
+
+class Test_NetworkResource(TestCase):
+    """
+    Tests for the Network resource.
+    """
+
+    def before(self):
+        self.api = falcon.API(middleware=[JSONify()])
+        self.resource = networks.NetworkResource()
+        self.api.add_route('/api/v0/network/{name}', self.resource)
+
+    def test_network_retrieve(self):
+        """
+        Verify retrieving a network.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            test_network = networks.Network.new(name='default')
+            # Verify if the network exists the data is returned
+            manager.get.return_value = test_network
+
+            body = self.simulate_request('/api/v0/network/default')
+            self.assertEqual(self.srmock.status, falcon.HTTP_200)
+
+            self.assertEqual(
+                json.loads(test_network.to_json()),
+                json.loads(body[0]))
+
+            # Verify no network returns the proper result
+            manager.get.reset_mock()
+            manager.get.side_effect = Exception
+
+            body = self.simulate_request('/api/v0/network/bogus')
+            self.assertEqual(falcon.HTTP_404, self.srmock.status)
+            self.assertEqual({}, json.loads(body[0]))
+
+    def test_network_create(self):
+        """
+        Verify creating a network.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            test_network = networks.Network.new(name='default')
+            # Verify with creation
+            manager.get.side_effect = (
+                Exception,
+                test_network,
+                test_network,
+                test_network
+            )
+
+            test_body = (
+                '{"name": "default", "type": "flannel_etcd", "options": {}}')
+
+            body = self.simulate_request(
+                '/api/v0/network/default', method='PUT', body=test_body)
+            self.assertEquals(falcon.HTTP_201, self.srmock.status)
+            result = json.loads(body[0])
+            self.assertEquals('default', result['name'])
+            self.assertEquals('flannel_etcd', result['type'])
+            self.assertEquals({}, result['options'])
+
+            # Verify with existing network
+            manager.get.return_value = CLUSTER
+            body = self.simulate_request(
+                '/api/v0/network/default', method='PUT', body=test_body)
+            self.assertEquals(falcon.HTTP_201, self.srmock.status)
+            self.assertEquals('default', result['name'])
+            self.assertEquals('flannel_etcd', result['type'])
+            self.assertEquals({}, result['options'])
+
+    def test_network_delete(self):
+        """
+        Verify deleting a network.
+        """
+        with mock.patch('cherrypy.engine.publish') as _publish:
+            manager = mock.MagicMock(StoreHandlerManager)
+            _publish.return_value = [manager]
+
+            # Verify with proper deletion
+            manager.get.return_value = MagicMock()
+            body = self.simulate_request(
+                '/api/v0/network/development', method='DELETE')
+            # Get is called to verify network exists
+            self.assertEquals(falcon.HTTP_200, self.srmock.status)
+            self.assertEquals('{}', body[0])
+
+            # Verify when key doesn't exist
+            manager.delete.side_effect = etcd.EtcdKeyNotFound
+            body = self.simulate_request(
+                '/api/v0/network/development', method='DELETE')
+            self.assertEquals(falcon.HTTP_404, self.srmock.status)
+            self.assertEquals('{}', body[0])

--- a/test/test_jobs_investigator.py
+++ b/test/test_jobs_investigator.py
@@ -24,7 +24,7 @@ from . import TestCase
 from commissaire.compat.urlparser import urlparse
 
 from commissaire.jobs.investigator import investigator
-from commissaire.handlers.models import Host
+from commissaire.handlers.models import Host, Cluster
 from commissaire.store.storehandlermanager import StoreHandlerManager
 from Queue import Queue
 from mock import MagicMock
@@ -71,7 +71,8 @@ class Test_JobsInvestigator(TestCase):
             manager = MagicMock(StoreHandlerManager)
             manager.get.return_value = Host(**json.loads(self.etcd_host))
 
-            request_queue.put_nowait((manager, to_investigate, 'host_only'))
+            request_queue.put_nowait((
+                manager, to_investigate, Cluster.new().__dict__))
             investigator(request_queue, response_queue, run_once=True)
 
             # Investigator saves *after* bootstrapping.


### PR DESCRIPTION
This adds support for using flannel in client-server mode. For more
information please see https://github.com/coreos/flannel/blob/master/Documentation/client-server.md

The following endpoints have been added:

- /api/v0/networks/
- /api/v0/network/{name}

A network is defined via a name, type, and options.

- name: The name of the network
- type: The type of network (currently flannel_etcd or flannel_server)
- options: Any options to define the network (currently address for flannel_server)

Example:

```javascript
  {
      "name": "mynetwork",
      "type": "flannel_server",
      "options": {
          "address": "192.168.152.101:8080"
      }
  }
```