### PR TITLE
Configuation format polishing

### DIFF
--- a/conf/commissaire.conf
+++ b/conf/commissaire.conf
@@ -4,16 +4,12 @@
     "register-store-handler": [
         {
             "name": "commissaire.store.etcdstorehandler",
-            "protocol": "http",
-            "host": "192.168.152.101",
-            "port": 2379,
+            "server_url": "http://192.168.152.101:2379",
             "models": ["*"]
         },
         {
             "name": "commissaire.store.kubestorehandler",
-            "protocol": "http",
-            "host": "192.168.152.102",
-            "port": 8080,
+            "server_url": "http://192.168.152.102:8080",
             "models": []
         }
     ],

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -108,9 +108,7 @@ commissaire_kubeproxy_service                 Name of the kubernetes proxy servi
 commissaire_restart_command                   Host restart command
 commissaire_upgrade_command                   Host upgrade command
 commissaire_bootstrap_ip                      The IP address of the host
-commissaire_kubernetes_api_server_scheme      The kubernetes api server scheme (http/https)
-commissaire_kubernetes_api_server_host        The kubernetes api server host
-commissaire_kubernetes_api_server_port        The kubernetes api server port
+commissaire_kubernetes_api_server_url         The kubernetes api server (scheme://host:port)
 commissaire_kubernetes_client_cert_path       Path to the kubernetes client certificate
 commissaire_kubernetes_client_key_path        Path to the kubernetes client key
 commissaire_kubernetes_client_cert_path_local Path to the local kubernetes client certificate
@@ -118,9 +116,7 @@ commissaire_kubernetes_client_key_path_local  Path to the local kubernetes clien
 commissaire_kubernetes_bearer_token           The bearer token used to contact kubernetes
 commissaire_docker_registry_host              The docker registry host
 commissaire_docker_registry_port              The docker registry port
-commissaire_etcd_scheme                       The etcd server scheme (http/https)
-commissaire_etcd_host                         The etcd host
-commissaire_etcd_port                         The etcd port
+commissaire_etcd_server_url                   The etcd server (scheme://host:port)
 commissaire_etcd_ca_path                      Path to the etcd certificate authority
 commissaire_etcd_client_cert_path             Path to the etcd client certificate
 commissaire_etcd_client_key_path              Path to the etcd client key

--- a/features/environment.py
+++ b/features/environment.py
@@ -85,15 +85,12 @@ def start_server(context, *args):
         server_cli_args += args
 
         if context.ETCD:
-            url = urlparse(context.ETCD)
             server_cli_args += [
                 '--register-store-handler',
                 '{{'
                 ' "name": "commissaire.store.etcdstorehandler",'
-                ' "protocol": "{0}",'
-                ' "host": "{1}",'
-                ' "port": {2}'
-                '}}'.format(url.scheme, url.hostname, url.port)]
+                ' "server_url": "{0}"'
+                '}}'.format(context.ETCD)]
 
         # Add any other server-args
         extra_server_args = context.config.userdata.get(

--- a/src/commissaire/compat/urlparser.py
+++ b/src/commissaire/compat/urlparser.py
@@ -21,9 +21,12 @@ from commissaire.compat import __python_version__
 
 if __python_version__ == '2':
     from urlparse import urlparse as _urlparse
+    from urlparse import urljoin as _urljoin
 else:
     from urllib.parse import urlparse as _urlparse
+    from urllib.parse import urljoin as _urljoin
 
 
-#: The proper urlparse function
+#: The proper URL functions
 urlparse = _urlparse
+urljoin = _urljoin

--- a/src/commissaire/constants.py
+++ b/src/commissaire/constants.py
@@ -37,19 +37,15 @@ DEFAULT_CLUSTER_NETWORK_JSON = {
 }
 
 # Default etcd configuration
+# (server URL provided by store handler)
 DEFAULT_ETCD_STORE_HANDLER = {
     'name': 'commissaire.store.etcdstorehandler',
-    'protocol': 'http',
-    'host': '127.0.0.1',
-    'port': 2379,
     'models': []
 }
 
 # Default Kubernetes configuration
+# (server URL provided by store handler)
 DEFAULT_KUBERNETES_STORE_HANDLER = {
     'name': 'commissaire.store.kubestorehandler',
-    'protocol': 'http',
-    'host': '127.0.0.1',
-    'port': 8080,
     'models': ['*']
 }

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -19,6 +19,7 @@ The kubernetes container manager package.
 import requests
 
 from commissaire import constants as C
+from commissaire.compat.urlparser import urljoin
 from commissaire.containermgr import ContainerManagerBase
 
 
@@ -37,9 +38,6 @@ class ContainerManager(ContainerManagerBase):
         :type config: dict
         """
         ContainerManagerBase.__init__(self, config)
-        self.scheme = config['protocol']
-        self.host = config['host']
-        self.port = config['port']
         self.con = requests.Session()
         token = config.get('token', None)
         if token:
@@ -58,8 +56,7 @@ class ContainerManager(ContainerManagerBase):
 
         # TODO: Verify TLS!!!
         self.con.verify = False
-        self.base_uri = '{0}://{1}:{2}/api/v1'.format(
-            self.scheme, self.host, self.port)
+        self.base_uri = urljoin(config['server_url'], '/api/v1')
         self.logger.info('Kubernetes Container Manager created: {0}'.format(
             self.base_uri))
         self.logger.debug(

--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,7 +1,7 @@
 {%- set OPTIONS="" %}
 
 {%- if commissaire_etcd_scheme is defined %}
-FLANNEL_ETCD="{{ commissaire_etcd_scheme }}://{{ commissaire_etcd_host }}:{{ commissaire_etcd_port }}"
+FLANNEL_ETCD="{{ commissaire_etcd_server_url }}
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
 {%- elif commissaire_flanneld_server is defined %}
 {#- commissaire_flanneld_server indicates a client/server model #}

--- a/src/commissaire/data/templates/kube_config
+++ b/src/commissaire/data/templates/kube_config
@@ -1,1 +1,1 @@
-KUBE_MASTER="--master={{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"
+KUBE_MASTER="--master={{ commissaire_kubernetes_api_server_url }}"

--- a/src/commissaire/data/templates/kubeconfig
+++ b/src/commissaire/data/templates/kubeconfig
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
     api-version: v1
     insecure-skip-tls-verify: true
-    server: {{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}
+    server: {{ commissaire_kubernetes_api_server_url }}
   name: cluster
 contexts:
 - context:

--- a/src/commissaire/data/templates/kubelet
+++ b/src/commissaire/data/templates/kubelet
@@ -1,3 +1,3 @@
 KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_HOSTNAME="--hostname_override={{ commissaire_bootstrap_ip }}"
-KUBELET_API_SERVER="--api_servers={{ commissaire_kubernetes_api_server_scheme }}://{{ commissaire_kubernetes_api_server_host }}:{{ commissaire_kubernetes_api_server_port }}"
+KUBELET_API_SERVER="--api_servers={{ commissaire_kubernetes_api_server_url }}"

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -374,9 +374,7 @@ class Transport:
         """
         # Need defaults for all required keys.
         etcd_config = {
-            'host': C.DEFAULT_ETCD_STORE_HANDLER['host'],
-            'port': C.DEFAULT_ETCD_STORE_HANDLER['port'],
-            'protocol': 'http'
+            'server_url': EtcdStoreHandler.DEFAULT_SERVER_URL
         }
 
         entries = store_manager.list_store_handlers()
@@ -397,9 +395,7 @@ class Transport:
         """
         # Need defaults for all required keys.
         kube_config = {
-            'host': C.DEFAULT_KUBERNETES_STORE_HANDLER['host'],
-            'port': C.DEFAULT_KUBERNETES_STORE_HANDLER['port'],
-            'protocol': 'http',
+            'server_url': KubernetesStoreHandler.DEFAULT_SERVER_URL,
             'token': ''
         }
 
@@ -447,10 +443,7 @@ class Transport:
         play_vars = {
             'commissaire_cluster_type': cluster_type,
             'commissaire_bootstrap_ip': ip,
-            'commissaire_kubernetes_api_server_scheme':
-                kube_config['protocol'],
-            'commissaire_kubernetes_api_server_host': kube_config['host'],
-            'commissaire_kubernetes_api_server_port': kube_config['port'],
+            'commissaire_kubernetes_api_server_url': kube_config['server_url'],
             'commissaire_kubernetes_bearer_token': kube_config['token'],
             # TODO: Where do we get this?
             'commissaire_docker_registry_host': '127.0.0.1',
@@ -490,13 +483,12 @@ class Transport:
             play_vars['commissaire_flanneld_server'] = network.options.get(
                 'address')
         elif network.type == 'flannel_etcd':
-            play_vars['commissaire_etcd_scheme'] = etcd_config['protocol']
-            play_vars['commissaire_etcd_host'] = etcd_config['host']
-            play_vars['commissaire_etcd_port'] = etcd_config['port']
+            play_vars['commissaire_etcd_server_url'] = etcd_config[
+                'server_url']
 
         # Provide the CA if etcd is being used over https
         if (
-                etcd_config['protocol'] == 'https' and
+                etcd_config['server_url'].startswith('https:') and
                 'certificate_ca_path' in etcd_config):
             play_vars['commissaire_etcd_ca_path'] = oscmd.etcd_ca
             play_vars['commissaire_etcd_ca_path_local'] = (

--- a/test/test_containermgr_kubernetes.py
+++ b/test/test_containermgr_kubernetes.py
@@ -23,9 +23,7 @@ from commissaire.compat.urlparser import urlparse
 from commissaire.containermgr.kubernetes import KubeContainerManager
 
 CONFIG = {
-    'protocol': 'http',
-    'host': '127.0.0.1',
-    'port': '8080',
+    'server_url': 'http://127.0.0.1:8080',
     'token': 'token'
 }
 

--- a/test/test_handlers_hosts.py
+++ b/test/test_handlers_hosts.py
@@ -146,9 +146,7 @@ class Test_HostStatusResource(TestCase):
         with mock.patch('cherrypy.engine.publish') as _publish:
             manager = mock.MagicMock(StoreHandlerManager)
             kube_container_mgr = KubeContainerManager({
-                'protocol': 'http',
-                'host': '127.0.0.1',
-                'port': '8080',
+                'server_url': 'http://127.0.0.1:8080',
                 'token': 'token'
             })
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -127,13 +127,30 @@ class Test_ConfigFile(TestCase):
         self.assertTrue(len(models) > 1)
         self.assertTrue(all(x.__name__.startswith('Host') for x in models))
 
+        store_manager = StoreHandlerManager()
+
         # Note, this config is missing required info.
         config = {
             'name': 'commissaire.store.etcdstorehandler',
             'certificate-path': '/path/to/cert',
             'models': ['*']
         }
+        self.assertRaises(
+            ConfigurationError, script.register_store_handler,
+            parser, store_manager, config)
+
         store_manager = StoreHandlerManager()
+
+        # Catch model conflicts (TestModel assigned to both handlers)
+        config = {
+            'name': 'commissaire.store.etcdstorehandler',
+            'models': ['*']
+        }
+        script.register_store_handler(parser, store_manager, config)
+        config = {
+            'name': 'commissaire.store.kubestorehandler',
+            'models': ['Host']
+        }
         self.assertRaises(
             ConfigurationError, script.register_store_handler,
             parser, store_manager, config)

--- a/test/test_store_kubestorehandler.py
+++ b/test/test_store_kubestorehandler.py
@@ -38,7 +38,7 @@ class Test_KubernetesStoreHandlerClass(_Test_StoreHandler):
         Sets up a fresh instance of the class before each run.
         """
         self.instance = self.cls(
-            {'protocol': 'http', 'host': '127.0.0.1', 'port': 8080})
+            {'server_url': 'http://127.0.0.1:8080'})
 
     def test__format_kwargs(self):
         """

--- a/test/test_transport_ansibleapi.py
+++ b/test/test_transport_ansibleapi.py
@@ -150,13 +150,13 @@ class Test_Transport(TestCase):
 
             # Check user-config to playbook-variable translation.
             etcd_config = {
-                'server_url': 'https://1.1.1.1:1234',
+                'server_url': 'https://192.168.1.1:1234',
                 'certificate_ca_path': '/path/to/etcd/ca/cert',
                 'certificate_path': '/path/to/etcd/client/cert',
                 'certificate_key_path': '/path/to/etcd/client/key'
             }
             kube_config = {
-                'server_url': 'https://2.2.2.2:4567',
+                'server_url': 'https://192.168.2.2:4567',
                 'certificate_path': '/path/to/kube/client/cert',
                 'certificate_key_path': '/path/to/kube/client/key'
             }
@@ -181,7 +181,7 @@ class Test_Transport(TestCase):
             play_vars = transport._run.call_args[0][4]
             self.assertEqual(
                 play_vars['commissaire_etcd_server_url'],
-                'https://1.1.1.1:1234')
+                'https://192.168.1.1:1234')
             self.assertEqual(
                 play_vars['commissaire_etcd_ca_path_local'],
                 '/path/to/etcd/ca/cert')

--- a/test/test_transport_ansibleapi.py
+++ b/test/test_transport_ansibleapi.py
@@ -150,17 +150,13 @@ class Test_Transport(TestCase):
 
             # Check user-config to playbook-variable translation.
             etcd_config = {
-                'protocol': 'https',
-                'host': '1.1.1.1',
-                'port': 1234,
+                'server_url': 'https://1.1.1.1:1234',
                 'certificate_ca_path': '/path/to/etcd/ca/cert',
                 'certificate_path': '/path/to/etcd/client/cert',
                 'certificate_key_path': '/path/to/etcd/client/key'
             }
             kube_config = {
-                'protocol': 'https',
-                'host': '2.2.2.2',
-                'port': 4567,
+                'server_url': 'https://2.2.2.2:4567',
                 'certificate_path': '/path/to/kube/client/cert',
                 'certificate_key_path': '/path/to/kube/client/key'
             }
@@ -184,11 +180,8 @@ class Test_Transport(TestCase):
                 'test/fake_key', store_manager, oscmd)
             play_vars = transport._run.call_args[0][4]
             self.assertEqual(
-                play_vars['commissaire_etcd_scheme'], 'https')
-            self.assertEqual(
-                play_vars['commissaire_etcd_host'], '1.1.1.1')
-            self.assertEqual(
-                play_vars['commissaire_etcd_port'], 1234)
+                play_vars['commissaire_etcd_server_url'],
+                'https://1.1.1.1:1234')
             self.assertEqual(
                 play_vars['commissaire_etcd_ca_path_local'],
                 '/path/to/etcd/ca/cert')


### PR DESCRIPTION
A bit of polishing around store handler configuration.  Docs will be a separate PR.

Changes:
 - Replace `host`/`port`/`protocol` keys with a single `server_url`.  I think this is less cumbersome for users and I see other projects using URLs in their config files.
 - A side-effect of the previous item is `etcd.Client` arguments are assembled from the `config` dictionary instead of `config` being passed through directly.  I think this is safer.
 - Wildcards in the `models` list makes accidental conflicts easier.  Assigning a model to multiple store handlers now raises an error.