### PR TITLE
bug: flanneld template no longer malformed.

### DIFF
--- a/src/commissaire/data/templates/flanneld
+++ b/src/commissaire/data/templates/flanneld
@@ -1,7 +1,7 @@
 {%- set OPTIONS="" %}
 
-{%- if commissaire_etcd_scheme is defined %}
-FLANNEL_ETCD="{{ commissaire_etcd_server_url }}
+{%- if commissaire_etcd_server_url is defined %}
+FLANNEL_ETCD="{{ commissaire_etcd_server_url }}"
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
 {%- elif commissaire_flanneld_server is defined %}
 {#- commissaire_flanneld_server indicates a client/server model #}


### PR DESCRIPTION
Found while testing the model clarification PR.

Fixes:

- No longer sensing on the deprecated scheme variable
- Added the missing quote