### PR TITLE
bug: Hosts without a cluster now gain the default network.

### DIFF
--- a/src/commissaire/handlers/clusters.py
+++ b/src/commissaire/handlers/clusters.py
@@ -168,6 +168,8 @@ class ClusterResource(Resource):
                 self.logger.error(
                     'Unable to parse cluster arguments: {0}'.format(error))
         try:
+            self.logger.debug('Looking for network {0}'.format(
+                args['network']))
             network = store_manager.get(
                 Network.new(name=args['network']))
         except KeyError:

--- a/src/commissaire/handlers/models.py
+++ b/src/commissaire/handlers/models.py
@@ -69,7 +69,7 @@ class Cluster(Model):
     _attribute_defaults = {
         'name': '', 'type': C.CLUSTER_TYPE_DEFAULT,
         'status': '', 'hostset': [],
-        'network': 'flannel_etcd',
+        'network': C.DEFAULT_CLUSTER_NETWORK_JSON['name'],
     }
     _primary_key = 'name'
 

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -119,7 +119,7 @@ def investigator(request_queue, response_queue, run_once=False):
         logger.debug('Attempting to register with relevant container '
                      'managers: cluster_data={0}'.format(cluster_data))
         for con_mgr in store_manager.list_container_managers(
-                cluster_data.get('type', [])):
+                cluster_data.get('type', '')):
             try:
                 logger.debug('Trying to register with {0}...'.format(
                     con_mgr.__class__.__name__))

--- a/src/commissaire/jobs/investigator.py
+++ b/src/commissaire/jobs/investigator.py
@@ -43,6 +43,8 @@ def investigator(request_queue, response_queue, run_once=False):
         # Statuses follow:
         # http://commissaire.readthedocs.org/en/latest/enums.html#host-statuses
         store_manager, to_investigate, cluster_data = request_queue.get()
+        if cluster_data is None:
+            cluster_data = {}
         address = to_investigate['address']
         remote_user = to_investigate['remote_user']
         logger.info('{0} is now in investigating.'.format(address))
@@ -114,9 +116,13 @@ def investigator(request_queue, response_queue, run_once=False):
             continue
 
         # Verify association with relevant container managers
+        logger.debug('Attempting to register with relevant container '
+                     'managers: cluster_data={0}'.format(cluster_data))
         for con_mgr in store_manager.list_container_managers(
-                cluster_data['type']):
+                cluster_data.get('type', [])):
             try:
+                logger.debug('Trying to register with {0}...'.format(
+                    con_mgr.__class__.__name__))
                 # Try 3 times waiting 5 seconds each time before giving up
                 for cnt in range(0, 3):
                     if con_mgr.node_registered(address):

--- a/src/commissaire/transport/ansibleapi.py
+++ b/src/commissaire/transport/ansibleapi.py
@@ -427,9 +427,14 @@ class Transport:
         self.logger.debug('Using {0} as the oscmd class for {1}'.format(
             oscmd.os_type, ip))
 
+        # cluster_data can be None. If it is change it to an empty dict
+        if cluster_data is None:
+            cluster_data = {}
         cluster_type = C.CLUSTER_TYPE_HOST
         network = Network.new(**C.DEFAULT_CLUSTER_NETWORK_JSON)
         try:
+            self.logger.debug('Grabbing cluster type from {0}'.format(
+                cluster_data))
             cluster = Cluster.new(**cluster_data)
             cluster_type = cluster.type
             network = store_manager.get(Network.new(name=cluster.network))
@@ -477,7 +482,6 @@ class Transport:
             'commissaire_kubeproxy_service': oscmd.kubelet_proxy_service,
         }
 
-        # TODO: get the data!!
         # If we are a flannel_server network then set the var
         if network.type == 'flannel_server':
             play_vars['commissaire_flanneld_server'] = network.options.get(


### PR DESCRIPTION
When a Host is not part of a cluster it doesn't have a network
associated with it. This was causing a problem during bootstrapping. Now
a host outside of any cluster will associate with the default network.

This change also makes sure that cluster_data is usable before
associating with a Container Manager.