### PR TITLE
Watcher queue now a manager/proxy based faux Queue.

### DIFF
--- a/src/commissaire/handlers/hosts.py
+++ b/src/commissaire/handlers/hosts.py
@@ -270,8 +270,11 @@ class HostResource(Resource):
         store_manager = cherrypy.engine.publish('get-store-manager')[0]
         try:
             host = Host.new(address=address)
-            store_manager.delete(host)
             WATCHER_QUEUE.dequeue(host)
+            store_manager.delete(host)
+            self.logger.debug(
+                'Deleted host {0} and dequeued it from the watcher.'.format(
+                    host.address))
             resp.status = falcon.HTTP_200
         except:
             resp.status = falcon.HTTP_404

--- a/src/commissaire/jobs/watcher.py
+++ b/src/commissaire/jobs/watcher.py
@@ -24,6 +24,7 @@ from commissaire.handlers.models import Hosts
 from commissaire.handlers import util
 from commissaire.transport import ansibleapi
 from commissaire.util.ssh import TemporarySSHKey
+from commissaire.queues import Empty
 
 
 def watcher(queue, store_manager, run_once=False):
@@ -60,7 +61,12 @@ def watcher(queue, store_manager, run_once=False):
             logger.info('No hosts found in the store.')
 
     while True:
-        host, last_run = queue.get()
+        try:
+            host, last_run = queue.get_nowait()
+        except Empty:
+            time.sleep(throttle)
+            continue
+
         logger.debug('Retrieved {0} from queue. Last check was {1}'.format(
             host.address, last_run))
         now = datetime.datetime.utcnow()

--- a/src/commissaire/queues.py
+++ b/src/commissaire/queues.py
@@ -17,14 +17,16 @@ All global queues.
 """
 
 from commissaire.model import Model
-from multiprocessing import Lock
+from multiprocessing import Manager
 from multiprocessing.queues import Empty
-from multiprocessing.queues import Queue as MPQueue
+
+#: manager instance used in IterableModelQueues
+manager = Manager()
 
 
-class IterableModelQueue(MPQueue):
+class IterableModelQueue:
     """
-    An iterable multiprocessing.queues.Queue that uses models and a cache for
+    An iterable Queue like class that uses models and adds basic
     dequeue support.
     """
 
@@ -38,22 +40,20 @@ class IterableModelQueue(MPQueue):
         :param kwargs: All keyword arguments.
         :type kwargs: dict
         """
-        MPQueue.__init__(self, *args, **kwargs)
-        self._lock = Lock()
-        self._cache = {}
+        self._queue = manager.list()
 
     def __iter__(self):
         """
         Adds iterable support to multiprocessing.queues.Queue.
         """
-        for item in self._cache.values():
+        for item in self._queue:
             yield item
         raise StopIteration()
 
     def get(self, *args, **kwargs):
         """
-        Returns an item off the queue and updates the cache. See documentation
-        on multiprocessing.queues.Queue
+        Returns an item off the queue. Arguments are ignored but accepted
+        to keep a similar interface with Queue.
 
         :param args: All non-keyword arguments.
         :type args: list
@@ -62,36 +62,34 @@ class IterableModelQueue(MPQueue):
         :returns: The item off the queue.
         :rtype: mixed
         """
-        item = super(IterableModelQueue, self).get(*args, **kwargs)
-        item_model = self._get_obj_model(item)
-        if item_model.primary_key in self._cache.keys():
-            del self._cache[item_model.primary_key]
-        return item
+        try:
+            return self._queue.pop(0)
+        except IndexError:
+            raise Empty
+
+    #: Forward function
+    get_nowait = get
 
     def dequeue(self, obj):
         """
-        Removes a specific item from the queue and cache.
+        Removes a specific item from the queue.
 
         :param obj: The item to deque.
         :type obj:  commissaire.model.Model
         """
-        with self._lock:
-            obj_model = self._get_obj_model(obj)
-            if obj_model.primary_key in self._cache.keys():
-                try:
-                    while True:
-                            item = self.get_nowait()
-                            item_model = self._get_obj_model(item)
-                            if item_model.primary_key != obj_model.primary_key:
-                                self.put(item)
-                            else:
-                                break
-                except Empty:
-                    pass
+        obj_model = self._get_obj_model(obj)
+        for x in range(0, len(self._queue)):
+            item = self._queue[x]
+            # If the instance is a tuple snag the first element
+            if isinstance(item, tuple):
+                item = item[0]
+            if obj_model.primary_key == item.primary_key:
+                self._queue.pop(x)
 
     def put(self, obj, *args, **kwargs):
         """
-        Puts a new object on the queue.
+        Puts a new object on the queue. Arguments are ignored but accepted
+        to keep a similar interface with Queue.
 
         :param obj: The object to put on the queue.
         :type obj: any
@@ -103,11 +101,16 @@ class IterableModelQueue(MPQueue):
         obj_model = self._get_obj_model(obj)
         for item in self:
             item_model = self._get_obj_model(item)
+            # Don't add the items if it is already in the queue
             if item_model.primary_key == obj_model.primary_key:
                 return
+        self._queue.append(obj)
 
-        self._cache[obj_model.primary_key] = obj
-        super(IterableModelQueue, self).put(obj)
+    #: See put
+    put_nowait = put
+
+    #: Forward function
+    qsize = lambda s: len(s._queue)  # NOQA
 
     def _get_obj_model(self, item):
         """

--- a/src/commissaire/queues.py
+++ b/src/commissaire/queues.py
@@ -85,6 +85,7 @@ class IterableModelQueue:
                 item = item[0]
             if obj_model.primary_key == item.primary_key:
                 self._queue.pop(x)
+                return
 
     def put(self, obj, *args, **kwargs):
         """


### PR DESCRIPTION
This change moves the WATCHER_QUEUE to be a faux Queue that uses an
underlying manager based proxy. This fixes issues where the old cache
system was not syncing across some processes.