### PR TITLE
commissaire.bus.BusMixin and a few fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 setuptools
 sphinx_rtd_theme
 requests
+kombu

--- a/src/commissaire/bus/__init__.py
+++ b/src/commissaire/bus/__init__.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Common bus class for Commissaire.
+"""
+
+import uuid
+
+
+class BusMixin:
+    """
+    Common methods for classes which utilize the Commissaire bus.
+
+    The mixed class requires the following:
+
+    :param logger: The class level logger.
+    :type logging: logging.Logger
+    :param connection: Connection to the bus.
+    :type connection: kombu.connection.Connection
+    :param producer: Producer instance for sending messages.
+    :type producer: kombu.messaging.Producer
+    """
+
+    @classmethod
+    def create_id(cls):
+        """
+        Creates a new unique identifier.
+
+        :returns: A unique identification string.
+        :rtype: str
+        """
+        return str(uuid.uuid4())
+
+    def request(self, routing_key, method, params={}, **kwargs):
+        """
+        Sends a request to a simple queue. Requests create the initial response
+        queue and wait for a response.
+
+        :param routing_key: The routing key to publish on.
+        :type routing_key: str
+        :param method: The remote method to request.
+        :type method: str
+        :param params: Keyword parameters to pass to the remote method.
+        :type params: dict
+        :param kwargs: Keyword arguments to pass to SimpleQueue
+        :type kwargs: dict
+        :returns: Result
+        :rtype: tuple
+        """
+        id = self.create_id()
+        response_queue_name = 'response-{}'.format(id)
+        self.logger.debug('Creating response queue "{}"'.format(
+            response_queue_name))
+        queue_opts = {
+            'auto_delete': True,
+            'durable': False,
+        }
+        if kwargs.get('queue_opts'):
+            queue_opts.update(kwargs.pop('queue_opts'))
+
+        self.logger.debug('Response queue arguments: {}'.format(kwargs))
+
+        response_queue = self.connection.SimpleQueue(
+            response_queue_name,
+            queue_opts=queue_opts,
+            **kwargs)
+
+        jsonrpc_msg = {
+            'jsonrpc': '2.0',
+            'id': id,
+            'method': method,
+            'params': params,
+        }
+        self.logger.debug('jsonrpc message for id "{}": "{}"'.format(
+            id, jsonrpc_msg))
+
+        self.producer.publish(
+            jsonrpc_msg,
+            routing_key,
+            declare=[self._exchange],
+            reply_to=response_queue_name)
+
+        self.logger.debug(
+            'Sent message id "{}" to "{}". Waiting on response...'.format(
+                id, response_queue_name))
+
+        result = response_queue.get(block=True, timeout=10)
+        result.ack()
+
+        if 'error' in result.payload.keys():
+            self.logger.warn(
+                'Error returned from the message id "{}"'.format(
+                    id, result.payload))
+
+        self.logger.debug(
+            'Result retrieved from response queue "{}": payload="{}"'.format(
+                response_queue_name, result))
+        self.logger.debug('Closing queue {}'.format(response_queue_name))
+        response_queue.close()
+        return result.payload

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -18,7 +18,7 @@ The kubernetes container manager package.
 
 import requests
 
-from urllib.parse import urljoin as _urljoin
+from urllib.parse import urljoin
 
 from commissaire import constants as C
 from commissaire.containermgr import ContainerManagerBase

--- a/src/commissaire/storage/__init__.py
+++ b/src/commissaire/storage/__init__.py
@@ -12,6 +12,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Storage related module for Commissaire.
+"""
+
 
 class ConfigurationError(Exception):
     """

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import unittest
 
-from commissaire.model import Model
+from commissaire.models import Model
 
 # Keep this list synchronized with oscmd modules.
 available_os_types = ('fedora', 'redhat', 'rhel', 'centos')
@@ -41,7 +42,7 @@ def get_fixture_file_path(filename):
         'Can not find path for config: {0}'.format(filename))
 
 
-class TestCase(TestBase):
+class TestCase(unittest.TestCase):
     """
     Parent class for all unittests.
     """
@@ -54,7 +55,7 @@ class TestModel(Model):
     """
     _json_type = dict
     _attribute_map = {
-        'foo': {'type': basestring}
+        'foo': {'type': str}
     }
     _attribute_defaults = {'foo': ''}
     _primary_key = 'foo'

--- a/test/test_bus.py
+++ b/test/test_bus.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for the commissaire.bus module.
+"""
+
+import uuid
+
+from unittest import mock
+
+from . import TestCase
+
+from commissaire import bus
+
+
+ID = str(uuid.uuid4())
+
+
+class TestCommissaireBusMixin(TestCase):
+    """
+    Tests for the CommissaireBusMixin
+    """
+
+    def test_create_id(self):
+        """
+        Verify BusMixin.create_id makes a unique identifier.
+        """
+        uid = bus.BusMixin.create_id()
+        # It should be a string
+        self.assertIs(str, type(uid))
+        # And it should be 36 chars in length (uuid.uuid4())
+        self.assertEquals(len(ID), len(uid))
+
+
+    def test_request(self):
+        """
+        Verify BusMixin.request can request method calls.
+        """
+        instance = bus.BusMixin() 
+        instance.logger = mock.MagicMock()
+        instance.connection = mock.MagicMock()
+        instance.producer = mock.MagicMock()
+        instance._exchange = 'exchange'
+
+        routing_key = 'routing_key'
+        method = 'ping'
+        params = {}
+        queue_opts={'durable': False, 'auto_delete': True}
+
+        instance.request(
+            routing_key, method, params=params)
+        # A new SimpleQueue should have been created
+        instance.connection.SimpleQueue.assert_called_once_with(
+            mock.ANY,
+            queue_opts=queue_opts
+        )
+        # A jsonrpc message should have been published to the bus
+        instance.producer.publish.assert_called_once_with(
+            {
+                'jsonrpc': '2.0',
+                'id': mock.ANY,
+                'method': method,
+                'params': params,
+            },
+            routing_key,
+            declare=[instance._exchange],
+            reply_to=mock.ANY)
+        # The simple queue should be used to get a response
+        instance.connection.SimpleQueue.__call__(
+            ).get.assert_called_once_with(block=True, timeout=mock.ANY)
+        # And finally the queue should be closed
+        instance.connection.SimpleQueue.__call__(
+            ).close.assert_called_once_with()


### PR DESCRIPTION
`commissaire.bus.BusMixin` provides common bus methods for classes which utilize the Commissaire bus. The mixin expects a number of attributes to be valid:
- logger: The class level logger.
- connection: Connection to the bus.
- producer: Producer instance for sending messages.

Also included in this commit bundle:
- Flake8 fixes
- Base unittest fixes
