### PR TITLE
config: read_config_file now returns the proper auth structure.

### DIFF
--- a/src/commissaire/util/config.py
+++ b/src/commissaire/util/config.py
@@ -73,6 +73,11 @@ def read_config_file(path=None):
             raise ValueError(
                 '{0}: "{1}" is missing a "name" member'.format(
                     path, auth_key))
+        # Since it's valid we can parse it down into the expected
+        # format for loading.
+        auth_plugin_name = json_object[auth_key].pop('name')
+        json_object[auth_key + '-kwargs'] = json_object[auth_key]
+        json_object[auth_key] = auth_plugin_name
 
     # Special case:
     #

--- a/test/test_util_config.py
+++ b/test/test_util_config.py
@@ -95,7 +95,12 @@ class Test_ConfigFile(TestCase):
                 mock.mock_open(read_data=json.dumps(data))) as _open:
             conf = config.read_config_file()
             self.assertIsInstance(conf, dict)
-            self.assertEquals(data, conf)
+            self.assertEquals(
+                data['authentication-plugin']['name'],
+                conf['authentication-plugin'])
+            self.assertEquals(
+                data['authentication-plugin']['users'],
+                conf['authentication-plugin-kwargs']['users'])
 
     def test_read_config_file_with_invalid_authentication_plugin(self):
         """


### PR DESCRIPTION
The structure expected by the server is defined more so by command line
parsing. Because of this it was much easier to force that structure in
the read_config_file parsing point prior to usage rather than having two
possible structures.

Needed for https://github.com/projectatomic/commissaire-http/pull/6
