### PR TITLE
models: Support pre-validation.

### DIFF
--- a/src/commissaire/constants.py
+++ b/src/commissaire/constants.py
@@ -22,6 +22,8 @@ CLUSTER_TYPE_HOST = 'host_only'
 CLUSTER_TYPE_KUBERNETES = 'kubernetes'
 #: Cluster type to use if none is specified
 CLUSTER_TYPE_DEFAULT = CLUSTER_TYPE_KUBERNETES
+#: All cluster types
+CLUSTER_TYPES = [CLUSTER_TYPE_HOST, CLUSTER_TYPE_KUBERNETES]
 
 #: Flannel using etcd as it's configuration end
 NETWORK_TYPE_FLANNEL_ETCD = 'flannel_etcd'

--- a/src/commissaire/models/__init__.py
+++ b/src/commissaire/models/__init__.py
@@ -173,13 +173,15 @@ class Model(object):
         # of going between native and json
         return json.loads(self.to_json(secure))
 
-    def _validate(self):
+    def _validate(self, errors=[]):
         """
         Validates the attribute data of the current instance.
 
+        :param errors: Errors from any pre-validation.
+        :type errors: list
+
         :raises: ValidationError
         """
-        errors = []
         for attr, spec in self._attribute_map.items():
             value = getattr(self, attr)
             if not isinstance(value, spec['type']):
@@ -300,6 +302,14 @@ class Cluster(Model):
                 data[key] = getattr(self, key)
         data['hosts'] = self.hosts
         return json.dumps(data)
+
+    def _validate(self):
+        errors = []
+        if self.type not in C.CLUSTER_TYPES:
+            errors.append(
+                'Cluster type must be one of the following: {}'.format(
+                    ', '.join(C.CLUSTER_TYPES)))
+        super()._validate(errors)
 
 
 class ClusterDeploy(Model):


### PR DESCRIPTION
`_validate` now accepts an optional errors list. This can be used when a
model has extra validation defined in it's `_validate` method as it can
pass it's error list to the parent `_validate` method.
