### PR TITLE
constants: Added CONFLICT to jsonrpc errors.

### DIFF
--- a/src/commissaire/constants.py
+++ b/src/commissaire/constants.py
@@ -59,4 +59,6 @@ JSONRPC_ERRORS = {
     'METHOD_NOT_FOUND': -32601,
     'INVALID_PARAMETERS': -32602,
     'INTERNAL_ERROR': -32603,
+    # Custom codes
+    'CONFLICT': -32049,
 }

--- a/src/commissaire/constants.py
+++ b/src/commissaire/constants.py
@@ -60,5 +60,5 @@ JSONRPC_ERRORS = {
     'INVALID_PARAMETERS': -32602,
     'INTERNAL_ERROR': -32603,
     # Custom codes
-    'CONFLICT': -32049,
+    'CONFLICT': 409,
 }


### PR DESCRIPTION
jsonrpc provides a space for custom errors. Since we use the same
structure for internal communication this change uses one of the custom
error codes for CONFLICT.

See: http://www.jsonrpc.org/specification#error_object
