### PR TITLE
Add Notification Support

### DIFF
--- a/src/commissaire/bus/__init__.py
+++ b/src/commissaire/bus/__init__.py
@@ -71,18 +71,13 @@ class BusMixin:
         """
         return str(uuid.uuid4())
 
-    def request(self, routing_key, method=None, params={}, **kwargs):
+    def request(self, routing_key, params={}, **kwargs):
         """
         Sends a request to a simple queue. Requests create the initial response
         queue and wait for a response.
 
-        For convenience, if a method argument is omitted then the last
-        segment of the routing_key is used as the method name.
-
         :param routing_key: The routing key to publish on.
         :type routing_key: str
-        :param method: The remote method to request.
-        :type method: str
         :param params: Keyword parameters to pass to the remote method.
         :type params: dict
         :param kwargs: Keyword arguments to pass to SimpleQueue
@@ -108,8 +103,7 @@ class BusMixin:
             queue_opts=queue_opts,
             **kwargs)
 
-        if method is None:
-            method = routing_key.split('.')[-1]
+        method = routing_key.split('.')[-1]
 
         jsonrpc_msg = {
             'jsonrpc': '2.0',

--- a/src/commissaire/bus/__init__.py
+++ b/src/commissaire/bus/__init__.py
@@ -153,3 +153,28 @@ class BusMixin:
                 error_data.get('data', {}))
 
         return payload
+
+    def notify(self, routing_key, params={}):
+        """
+        Sends a notification to a topic.
+
+        :param routing_key: The routing key to publish on.
+        :type routing_key: str
+        """
+        method = routing_key.split('.')[-1]
+
+        jsonrpc_msg = {
+            'jsonrpc': '2.0',
+            'method': method,
+            'params': params,
+        }
+        self.logger.debug(
+            'jsonrpc notification for id: {}"'.format(jsonrpc_msg))
+
+        self.producer.publish(
+            jsonrpc_msg,
+            routing_key,
+            declare=[self._exchange])
+
+        self.logger.debug(
+            'Sent notification to topic "{}".'.format(routing_key))


### PR DESCRIPTION
This will be used in `commissaire-http` to send of async requests to `investigator`.

I also included the removal of the `method` parameter in `request` since we no longer use it.
