### PR TITLE
Allow for multiple authentication plugins in config

### DIFF
--- a/doc/examples/insecure_config.rst
+++ b/doc/examples/insecure_config.rst
@@ -13,12 +13,12 @@
          "models": []
        }
      ],
-     "authentication-plugin": {
+     "authentication-plugins": [{
        "name": "commissaire.authentication.httpbasicauth",
        "users": {
          "a": {
            "hash": "$2a$12$GlBCEIwz85QZUCkWYj11he6HaRHufzIvwQjlKeu7Rwmqi/mWOpRXK"
          }
        }
-     }
+     }]
    }

--- a/doc/examples/secure_config.rst
+++ b/doc/examples/secure_config.rst
@@ -15,9 +15,8 @@
          "models": []
        }
      ],
-     "authentication-plugin": {
+     "authentication-plugins": [{
        "name": "commissaire.authentication.httpbasicauth",
        "filepath": "conf/users.json"
-     }
+     }]
    }
-

--- a/src/commissaire/util/config.py
+++ b/src/commissaire/util/config.py
@@ -26,6 +26,24 @@ class ConfigurationError(Exception):
     pass
 
 
+def _normalize_member_names(json_object):
+    """
+    Normalize member names by converting hyphens to underscores.
+
+    :param json_object: Dictionary to normalize.
+    :type json_object: dict
+    :returns: A normalized dictionary.
+    :rtype: dict
+    """
+    normalized = {}
+    for k, v in json_object.items():
+        k = k.replace('-', '_')
+        if isinstance(v, dict):
+            v = _normalize_member_names(v)
+        normalized[k] = v
+    return normalized
+
+
 def read_config_file(path=None):
     """
     Attempts to parse a configuration file, formatted as a JSON object.
@@ -61,20 +79,8 @@ def read_config_file(path=None):
         raise TypeError(
             '{0}: File content must be a JSON object'.format(path))
 
-    def normalize_member_names(json_object):
-        """
-        Normalize member names by converting hyphens to underscores.
-        """
-        normalized = {}
-        for k, v in json_object.items():
-            k = k.replace('-', '_')
-            if isinstance(v, dict):
-                v = normalize_member_names(v)
-            normalized[k] = v
-        return normalized
-
     # Recursively normalize the JSON member names.
-    json_object = normalize_member_names(json_object)
+    json_object = _normalize_member_names(json_object)
 
     # Special case:
     #

--- a/src/commissaire/util/config.py
+++ b/src/commissaire/util/config.py
@@ -70,14 +70,14 @@ def read_config_file(path=None):
         with open(path, 'r') as fp:
             json_object = json.load(fp)
         if using_default:
-            print('Using configuration in {0}'.format(path))
+            print('Using configuration in {}'.format(path))
     except IOError:
         if not using_default:
             raise
 
     if type(json_object) is not dict:
         raise TypeError(
-            '{0}: File content must be a JSON object'.format(path))
+            '{}: File content must be a JSON object'.format(path))
 
     # Recursively normalize the JSON member names.
     json_object = _normalize_member_names(json_object)
@@ -96,7 +96,7 @@ def read_config_file(path=None):
                 path, auth_plugins, type(auth_plugins)))
 
     for plugin in auth_plugins:
-        if type(plugin) is dict:
+        if isinstance(plugin, dict):
             if 'name' not in plugin.keys():
                 raise ValueError(
                     '{}: "{}" is missing a "name" member'.format(
@@ -114,7 +114,7 @@ def read_config_file(path=None):
     # be specified as a JSON object or a list of JSON objects.
     handler_key = 'storage_handlers'
     handler_list = json_object.get(handler_key)
-    if type(handler_list) is dict:
+    if isinstance(handler_list, dict):
         json_object[handler_key] = [handler_list]
 
     return json_object

--- a/test/test_util_config.py
+++ b/test/test_util_config.py
@@ -53,6 +53,7 @@ class Test_ConfigFile(TestCase):
                 mock.mock_open(read_data=json.dumps(data))) as _open:
             conf = config.read_config_file()
             self.assertIsInstance(conf, dict)
+            data['authentication_plugins'] = {}
             self.assertEquals(data, conf)
 
     def test_read_config_file_with_invalid_data(self):
@@ -79,6 +80,7 @@ class Test_ConfigFile(TestCase):
             conf = config.read_config_file()
             self.assertIsInstance(conf, dict)
             data['storage_handlers'] = [data['storage_handlers']]
+            data['authentication_plugins'] = {}
             self.assertEquals(data, conf)
 
     def test_read_config_file_with_valid_authentication_plugin(self):
@@ -86,22 +88,22 @@ class Test_ConfigFile(TestCase):
         Verify the read_config_file function parses valid
         authentication_plugin directives.
         """
+        plugin_name = 'commissaire_htp.authentication.httpbasicauth'
         data = {
-            'authentication_plugin': {
-                'name': 'commissaire_htp.authentication.httpbasicauth',
+            'authentication_plugins': [{
+                'name': plugin_name,
                 'users': {},
-            }
+            }]
         }
         with mock.patch('builtins.open',
                 mock.mock_open(read_data=json.dumps(data))) as _open:
             conf = config.read_config_file()
             self.assertIsInstance(conf, dict)
+            self.assertTrue(
+                plugin_name in conf['authentication_plugins'].keys())
             self.assertEquals(
-                data['authentication_plugin']['name'],
-                conf['authentication_plugin'])
-            self.assertEquals(
-                data['authentication_plugin']['users'],
-                conf['authentication_plugin_kwargs']['users'])
+                data['authentication_plugins'][0]['users'],
+                conf['authentication_plugins'][plugin_name]['users'])
 
     def test_read_config_file_with_invalid_authentication_plugin(self):
         """
@@ -109,8 +111,7 @@ class Test_ConfigFile(TestCase):
         authentication_plugin directives.
         """
         data = {
-            'authentication_plugin': {
-            }
+            'authentication_plugins': [{}]
         }
         with mock.patch('builtins.open',
                 mock.mock_open(read_data=json.dumps(data))) as _open:


### PR DESCRIPTION
This change updates the configuration file format to have a list of `Authenticators` (aka authentication plugins) instead of a single one. This is needed for https://github.com/projectatomic/commissaire-http/pull/34.
- Type checking and formatting updates.
- Examples now use `authentication-plugins` in config.
- Multiple authentication plugin support.
- Moved `normalize_member_names` to full function.
