### PR TITLE
test: Updated bdd doc and requirements.

### DIFF
--- a/bdd-requirements.txt
+++ b/bdd-requirements.txt
@@ -1,3 +1,6 @@
-git+https://github.com/projectatomic/commissaire-http.git #license=GPLv3
-git+https://github.com/projectatomic/commissaire-service.git #license=GPLv3
-git+https://github.com/projectatomic/commctl.git #license=LGPLv2
+#git+https://github.com/projectatomic/commissaire-http.git #license=GPLv3
+../commissaire-http #license=GPLv3+
+#git+https://github.com/projectatomic/commissaire-service.git #license=GPLv3
+../commissaire-service #license=GPLv3
+#git+https://github.com/projectatomic/commctl.git #license=LGPLv2
+../commctl #license=LGPLv2

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -156,7 +156,18 @@ End-to-End/BDD Testing
     Currently not ported to new architecture.
 
 commissaire uses `Behave <http://pythonhosted.org/behave/>`_ to execute
-end to end/BDD tests.
+end to end/BDD tests. You will need to have the following in your parent
+directory to properly be able to execute tests locally.
+
+.. code-block:: shell
+
+   $ ls ../ | grep 'comm'
+   commctl
+   commissaire
+   commissaire-http
+   commissaire-service
+   $
+
 
 To run e2e/bdd tests locally and see where your code stands:
 


### PR DESCRIPTION
bdd-requirements.txt now points to install points in the parent
directory. This makes it easy to test local work instead of testing what
is already checked in upstream.

Part of #30 