### PR TITLE
util: Added date helper functions.

### DIFF
--- a/doc/apidoc/commissaire.util.date.rst
+++ b/doc/apidoc/commissaire.util.date.rst
@@ -1,0 +1,7 @@
+commissaire.util.date module
+============================
+
+.. automodule:: commissaire.util.date
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/apidoc/commissaire.util.rst
+++ b/doc/apidoc/commissaire.util.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
 
    commissaire.util.config
+   commissaire.util.date
    commissaire.util.logging
    commissaire.util.ssh
 

--- a/src/commissaire/util/date.py
+++ b/src/commissaire/util/date.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Date/Time related utilities.
+"""
+
+import datetime
+
+from commissaire import constants as C
+
+
+def now():
+    """
+    Returns the date and time right now.
+
+    :returns: The date and time right now.
+    :rtype: datetime.datetime
+    """
+    return datetime.datetime.utcnow()
+
+
+def formatted_dt(dt=None):
+    """
+    Returns the date and time in the format expected by all components.
+
+    :param dt: Optional datetime to format.
+    :type dt: datetime.datetime
+    :returns: The date and time in the expected format.
+    :rtype: str
+    """
+    if dt is None:
+        dt = now()
+    return datetime.datetime.strftime(dt, C.DATE_FORMAT)

--- a/test/test_util_date.py
+++ b/test/test_util_date.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire.util.date module.
+"""
+
+from unittest import mock
+
+from . import TestCase
+
+from commissaire.util import date
+
+
+#: datetime instance to use in tests
+DT = date.datetime.datetime.utcnow()
+#: isoformat of DT used in tests
+ISOFORMAT = DT.isoformat()
+
+
+class Test_now(TestCase):
+    """
+    Tests the now function.
+    """
+
+    def test_now(self):
+        """
+        Test the now function.
+        """
+        with mock.patch('datetime.datetime') as _dt:
+            _dt.utcnow.return_value = DT
+            self.assertEquals(DT, date.now())
+
+
+class Test_formatted_dt(TestCase):
+    """
+    Tests the formatted_dt function.
+    """
+
+    def test_formatted_dt(self):
+        """
+        Test the formatted_dt function with no input.
+        """
+        with mock.patch('datetime.datetime') as _dt:
+            _dt.utcnow.return_value = DT
+            _dt.strftime.return_value = ISOFORMAT
+            self.assertEquals(ISOFORMAT, date.formatted_dt())
+
+    def test_formatted_dt_with_datetime(self):
+        """
+        Test the formatted_dt function with a datetime.
+        """
+        with mock.patch('datetime.datetime') as _dt:
+            _dt.utcnow.return_value = DT
+            _dt.strftime.return_value = ISOFORMAT
+            self.assertEquals(ISOFORMAT, date.formatted_dt(DT))


### PR DESCRIPTION
- ``now``: Returns the proper datetime.datetime instance
- ``formatted_dt``: Formats a datetime.datetime, or uses now if none is
  provided