### PR TITLE
Fix vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,9 +105,6 @@ Vagrant.configure(2) do |config|
         mkdir --parents /home/vagrant/.ssh
         cp /home/vagrant/sync/features/id_rsa{,.pub} /home/vagrant/.ssh
         cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
-        echo "===> Updating the system"
-        sudo atomic host upgrade
-        sudo systemctl reboot
       SHELL
     # End fedora-atomic
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(2) do |config|
         echo "===> Set flannel network"
         sudo etcdctl --endpoint=http://192.168.152.101:2379 set '/atomic01/network/config' '{"Network": "172.16.0.0/12", "SubnetLen": 24, "Backend": {"Type": "vxlan"}}'
         echo "===> Configure redis"
-        sudo sed -i "s/127.0.0.1/192.168.152.101/g" /etc/redis.conf
+        sudo sed -i "s/127.0.0.1/0.0.0.0/g" /etc/redis.conf
         sudo systemctl enable redis
         sudo systemctl start redis
       SHELL
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
         echo "===> Installing kubernetes"
         sudo dnf install -y kubernetes-master.x86_64
         echo "===> Configuring kubernetes"
-        sudo sed -i "s|insecure-bind-address=127.0.0.1|insecure-bind-address=192.168.152.102|g" /etc/kubernetes/apiserver
+        sudo sed -i "s|insecure-bind-address=127.0.0.1|insecure-bind-address=0.0.0.0|g" /etc/kubernetes/apiserver
         sudo sed -i "s|etcd-servers=http://127.0.0.1:2379|etcd-servers=http://192.168.152.101:2379|g" /etc/kubernetes/apiserver
         echo "===> Starting kubernetes"
         sudo systemctl enable kube-apiserver kube-scheduler kube-controller-manager
@@ -114,7 +114,7 @@ Vagrant.configure(2) do |config|
 
   # Development commissaire server and services
   # NOTE: This must start after etcd.
-  config.vm.define "commissaire", primary: true do |commissaire|
+  config.vm.define "commissaire", primary: true, autostart: false do |commissaire|
     commissaire.vm.box = "fedora/25-cloud-base"
     commissaire.vm.provider :libvirt do |domain|
      domain.memory = 1024
@@ -149,7 +149,7 @@ Vagrant.configure(2) do |config|
       sudo chmod 644 /etc/systemd/system/commissaire-server.service
       sudo mkdir --parents /etc/commissaire
       sudo cp /vagrant/commissaire-http/conf/commissaire.conf /etc/commissaire/commissaire.conf
-      sudo sed -i 's|"listen-interface": "127.0.0.1"|"listen-interface": "192.168.152.100"|g' /etc/commissaire/commissaire.conf
+      sudo sed -i 's|"listen-interface": "127.0.0.1"|"listen-interface": "0.0.0.0"|g' /etc/commissaire/commissaire.conf
       sudo sed -i 's|"bus-uri": "redis://127.0.0.1:6379/"|"bus-uri": "redis://192.168.152.101:6379/"|g' /etc/commissaire/commissaire.conf
       sudo sed -i 's|^ExecStart=.*|ExecStart=/bin/bash -c ". /home/vagrant/commissaire_env/bin/activate \\&\\& commissaire-server -c /etc/commissaire/commissaire.conf"|' /etc/systemd/system/commissaire-server.service
       sudo sed -i 's|Type=simple|\&\\nWorkingDirectory=/vagrant|' /etc/systemd/system/commissaire-server.service

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -44,11 +44,11 @@ vagrant box will attempt to mount them over SSH.
 
 
 To run the vagrant development environment make sure you have a support
-virtualization system as well as vagrant installed and execute ``vagrant up``.
+virtualization system as well as vagrant installed and execute ``./tools/vagrantup``.
 
 .. warning::
 
-   The initial run updates the systems and can take some time. To provision faster try ``vagrant up --parallel servers fedora-cloud fedora-atomic && vagrant up commissaire``.
+   If you want to use the ``vagrant`` command directly note that you will have to follow the same start up process used in ``./tools/vagrantup``
 
 .. note::
 
@@ -66,11 +66,11 @@ virtualization system as well as vagrant installed and execute ``vagrant up``.
 ==================== =============== ================ =========
 Server               IP              OS               AutoStart
 ==================== =============== ================ =========
-Servers (etcd/redis) 192.168.152.101 Fedora Cloud 24  Yes
-Fedora Node          192.168.152.110 Fedora Cloud 24  Yes
-Fedora Atomic Node   192.168.152.111 Fedora Atomic 24 Yes
-Commissaire          192.168.152.100 Fedora Cloud 24  Yes
-Kubernetes           192.168.152.102 Fedora Cloud 24  No
+Servers (etcd/redis) 192.168.152.101 Fedora Cloud 25  Yes
+Fedora Node          192.168.152.110 Fedora Cloud 25  Yes
+Fedora Atomic Node   192.168.152.111 Fedora Atomic 25 Yes
+Commissaire          192.168.152.100 Fedora Cloud 25  No
+Kubernetes           192.168.152.102 Fedora Cloud 25  No
 ==================== =============== ================ =========
 
 For more information see the `Vagrant site <https://www.vagrantup.com>`_.

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -52,12 +52,11 @@ virtualization system as well as vagrant installed and execute ``./tools/vagrant
 
 .. note::
 
-   The ``fedora-atomic`` host currently requires a manual work-around to
-   mount the shared folder at ``/home/vagrant/sync``.  After the box is up
-   the first time, run ``vagrant ssh fedora-atomic`` to log into the virtual
-   machine, then run ``sudo rpm-ostree install fuse-sshfs``.  Exit back out
-   to the host machine and restart the virtual machine with ``vagrant reload
-   fedora-atomic``.
+   If you decide to use the ``vagrant`` command directly, the ``fedora-atomic`` host will
+   require a manual work-around to mount the shared folder at ``/home/vagrant/sync``.
+   After the box is up the first time, run ``vagrant ssh fedora-atomic`` to log into the
+   virtual machine, then run ``sudo rpm-ostree install fuse-sshfs``.  Exit back out to
+   the host machine and restart the virtual machine with ``vagrant reload fedora-atomic``.
 
 .. note::
 

--- a/tools/vagrantup
+++ b/tools/vagrantup
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# NOTE: We use the exit code as a workaround for fedora-atomic + sshfs.
+#
+
+vagrant up servers
+vagrant up kubernetes
+vagrant up --parallel commissaire fedora-cloud
+vagrant up fedora-atomic
+if [ $? != 0 ]; then
+    echo "Installing fuse-sshfs in fedora-atomc"
+    vagrant ssh fedora-atomic -c 'sudo rpm-ostree install fuse-sshfs'
+    vagrant reload fedora-atomic
+fi


### PR DESCRIPTION
The root cause of ``vagrant up`` not starting all expected services ended up being around access to the external interfaces. By switching over to ```0.0.0.0``` the services are able to to bind. This change also adds a ``vagrantup`` tool which starts the machines in the right order and executes our workaround for ```fedora-atomic``` and ```fuse-sshfs```.

While I was in the neighborhood I updated the vagrant docs as well.