### PR TITLE
container: Added VOLUME for configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM fedora:25
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
-ENV MHM_RELEASE v0.1.0
-ENV PYTHONPATH  /commissaire/src/
-
 # Install required dependencies and commissaire
 RUN dnf -y update && dnf -y install --setopt=tsflags=nodocs rsync openssh-clients redhat-rpm-config python3-pip python3-virtualenv git gcc libffi-devel openssl-devel etcd redis; dnf clean all && \
 git clone https://github.com/projectatomic/commissaire-service.git && \
@@ -33,5 +30,7 @@ VOLUME /etc/commissaire/
 
 # commissaire-server address
 EXPOSE 8000
+# Run everything from /commissaire
 WORKDIR /commissaire
+# Execute the all-in-one-script
 CMD /commissaire/startup-all-in-one.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ cd .. && \
 pip freeze > /installed-python-deps.txt && \
 dnf remove -y gcc git redhat-rpm-config libffi-devel && \
 dnf clean all && \
-mkdir -p /etc/commissaire && \
-cp -r /commissaire-service/conf/*.conf /etc/commissaire/ && \
-cp -r /commissaire-http/conf/*.conf /etc/commissaire/ && \
-sed -i 's|"listen-interface": "127.0.0.1"|"listen-interface": "0.0.0.0"|' /etc/commissaire/commissaire.conf
+mkdir -p /etc/commissaire
 
 # Add the all-in-one start script
 ADD tools/startup-all-in-one.sh /commissaire/
 # Add the etcd init script
 ADD tools/etcd_init.sh /commissaire/
+
+# Configuration directory. Use --volume=/path/to/your/configs:/etc/commissaire
+VOLUME /etc/commissaire/
 
 # commissaire-server address
 EXPOSE 8000


### PR DESCRIPTION
This change allows the all-in-one container to load config via a volume. This change also removes unneeded lines and adds more comments.

To run:
```
    docker run \
    --volume=/pathto/commissaire_configs:/etc/commissaire:Z \
    -d -p 8000:8000 --name commissaire \
    commissaire
```