### PR TITLE
container: Added VOLUME for data.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:25
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 # Install required dependencies and commissaire
-RUN dnf -y update && dnf -y install --setopt=tsflags=nodocs rsync openssh-clients redhat-rpm-config python3-pip python3-virtualenv git gcc libffi-devel openssl-devel etcd redis; dnf clean all && \
+RUN dnf -y update && dnf -y install --setopt=tsflags=nodocs openssh-clients redhat-rpm-config python3-pip python3-virtualenv git gcc libffi-devel openssl-devel etcd redis; dnf clean all && \
 git clone https://github.com/projectatomic/commissaire-service.git && \
 git clone https://github.com/projectatomic/commissaire-http.git && \
 virtualenv-3 /environment && \
@@ -18,7 +18,8 @@ cd .. && \
 pip freeze > /installed-python-deps.txt && \
 dnf remove -y gcc git redhat-rpm-config libffi-devel && \
 dnf clean all && \
-mkdir -p /etc/commissaire
+sed -i 's|dir /var/lib/redis|dir /data/redis|g' /etc/redis.conf && \
+mkdir -p /etc/commissaire /data/{redis,etcd}
 
 # Add the all-in-one start script
 ADD tools/startup-all-in-one.sh /commissaire/
@@ -27,6 +28,8 @@ ADD tools/etcd_init.sh /commissaire/
 
 # Configuration directory. Use --volume=/path/to/your/configs:/etc/commissaire
 VOLUME /etc/commissaire/
+# Directory for data
+VOLUME /data
 
 # commissaire-server address
 EXPOSE 8000

--- a/tools/startup-all-in-one.sh
+++ b/tools/startup-all-in-one.sh
@@ -4,8 +4,8 @@
 set -eo pipefail
 
 # Start up required services
-redis-server &
-etcd &
+redis-server /etc/redis.conf &
+etcd --data-dir=/data/etcd/ &
 
 # Enter the virtual environment
 . /environment/bin/activate


### PR DESCRIPTION
This change allows the all-in-one container to store data in a volume.
It also removes rsync from the install as it is no longer required.

To run:
```
    docker run \
    --volume=/pathto/commissaire_configs:/etc/commissaire:Z \
    --volume=/pathto/data:/my_data_dir:Z \
    -d -p 8000:8000 --name commissaire \
    commissaire
```