### PR TITLE
logging: Switch to lazy string formatting

### DIFF
--- a/src/commissaire/bus/__init__.py
+++ b/src/commissaire/bus/__init__.py
@@ -129,8 +129,7 @@ class BusMixin:
         """
         id = self.create_id()
         response_queue_name = 'response-{}'.format(id)
-        self.logger.debug('Creating response queue "{}"'.format(
-            response_queue_name))
+        self.logger.debug('Creating response queue "%s"', response_queue_name)
         queue_opts = {
             'auto_delete': True,
             'durable': False,
@@ -138,7 +137,7 @@ class BusMixin:
         if kwargs.get('queue_opts'):
             queue_opts.update(kwargs.pop('queue_opts'))
 
-        self.logger.debug('Response queue arguments: {}'.format(kwargs))
+        self.logger.debug('Response queue arguments: %s', kwargs)
 
         response_queue = self.connection.SimpleQueue(
             response_queue_name,
@@ -153,8 +152,8 @@ class BusMixin:
             'method': method,
             'params': params,
         }
-        self.logger.debug('jsonrpc message for id "{}": "{}"'.format(
-            id, jsonrpc_msg))
+        self.logger.debug(
+            'jsonrpc message for id "%s": "%s"', id, jsonrpc_msg)
 
         self.producer.publish(
             jsonrpc_msg,
@@ -163,8 +162,8 @@ class BusMixin:
             reply_to=response_queue_name)
 
         self.logger.debug(
-            'Sent message id "{}" to "{}". Waiting on response...'.format(
-                id, response_queue_name))
+            'Sent message id "%s" to "%s". Waiting on response...',
+            id, response_queue_name)
 
         result = response_queue.get(block=True, timeout=10)
         result.ack()
@@ -174,15 +173,15 @@ class BusMixin:
             payload = json.loads(payload)
 
         self.logger.debug(
-            'Result retrieved from response queue "{}": result="{}"'.format(
-                response_queue_name, result))
-        self.logger.debug('Closing queue {}'.format(response_queue_name))
+            'Result retrieved from response queue "%s": result="%s"',
+            response_queue_name, result)
+        self.logger.debug('Closing queue %s', response_queue_name)
         response_queue.close()
 
         if 'error' in payload:
             error_data = payload['error']
             self.logger.warn(
-                'Message "{}" contains error: {}'.format(id, error_data))
+                'Message "%s" contains error: %s', id, error_data)
             message = error_data.get('message', 'Internal error')
             code = error_data.get('code', C.JSONRPC_ERRORS['INTERNAL_ERROR'])
             data = error_data.get('data', {})
@@ -210,7 +209,7 @@ class BusMixin:
             'params': params,
         }
         self.logger.debug(
-            'jsonrpc notification for id: {}"'.format(jsonrpc_msg))
+            'jsonrpc notification for id: %s"', jsonrpc_msg)
 
         self.producer.publish(
             jsonrpc_msg,
@@ -218,4 +217,4 @@ class BusMixin:
             declare=[self._exchange])
 
         self.logger.debug(
-            'Sent notification to topic "{}".'.format(routing_key))
+            'Sent notification to topic "%s".', routing_key)

--- a/src/commissaire/containermgr/kubernetes/__init__.py
+++ b/src/commissaire/containermgr/kubernetes/__init__.py
@@ -45,24 +45,24 @@ class KubeContainerManager(ContainerManagerBase):
         if token:
             self.con.headers['Authorization'] = 'Bearer {}'.format(token)
             self.logger.info('Using bearer token')
-            self.logger.debug('Bearer token: {}'.format(token))
+            self.logger.debug('Bearer token: %s', token)
 
         certificate_path = config.get('certificate_path')
         certificate_key_path = config.get('certificate_key_path')
         if certificate_path and certificate_key_path:
             self.con.cert = (certificate_path, certificate_key_path)
             self.logger.info(
-                'Using client side certificate. Certificate path: {} '
-                'Certificate Key Path: {}'.format(
-                    certificate_path, certificate_key_path))
+                'Using client side certificate. Certificate path: %s '
+                'Certificate Key Path: %s',
+                certificate_path, certificate_key_path)
 
         # TODO: Verify TLS!!!
         self.con.verify = False
         self.base_uri = urljoin(config['server_url'], '/api/v1')
-        self.logger.info('Kubernetes Container Manager created: {}'.format(
-            self.base_uri))
+        self.logger.info(
+            'Kubernetes Container Manager created: %s', self.base_uri)
         self.logger.debug(
-            'Kubernetes Container Manager: {}'.format(self.__dict__))
+            'Kubernetes Container Manager: %s', self.__dict__)
 
     @classmethod
     def check_config(cls, config):
@@ -124,11 +124,11 @@ class KubeContainerManager(ContainerManagerBase):
         :returns: requests.Response
         """
         part = self._fix_part(part)
-        self.logger.debug('Executing GET for {}'.format(part))
+        self.logger.debug('Executing GET for %s', part)
         resp = self.con.get(
             '{}{}'.format(self.base_uri, part), *args, **kwargs)
-        self.logger.debug('Response for {}. Status: {}'.format(
-            part, resp.status_code))
+        self.logger.debug(
+            'Response for %s. Status: %s', part, resp.status_code)
         return resp
 
     def _delete(self, part, *args, **kwargs):
@@ -146,11 +146,11 @@ class KubeContainerManager(ContainerManagerBase):
         :returns: requests.Response
         """
         part = self._fix_part(part)
-        self.logger.debug('Executing DELETE for {}.'.format(part))
+        self.logger.debug('Executing DELETE for %s.', part)
         resp = self.con.delete(
             '{}{}'.format(self.base_uri, part), *args, **kwargs)
-        self.logger.debug('Response for {}. Status: {}'.format(
-            part, resp.status_code))
+        self.logger.debug(
+            'Response for %s. Status: %s', part, resp.status_code)
         return resp
 
     def _put(self, part, payload, *args, **kwargs):
@@ -169,13 +169,13 @@ class KubeContainerManager(ContainerManagerBase):
         """
         part = self._fix_part(part)
         payload_str = json.dumps(payload)
-        self.logger.debug('Executing PUT for {}. Payload={}'.format(
-            part, payload_str))
+        self.logger.debug(
+            'Executing PUT for %s. Payload=%s', part, payload_str)
         resp = self.con.put(
             '{}{}'.format(self.base_uri, part),
             data=payload_str, *args, **kwargs)
-        self.logger.debug('Response for {}. Status: {}'.format(
-            part, resp.status_code))
+        self.logger.debug(
+            'Response for %s. Status: %s', part, resp.status_code)
         return resp
 
     def _post(self, part, payload, *args, **kwargs):
@@ -194,13 +194,13 @@ class KubeContainerManager(ContainerManagerBase):
         """
         part = self._fix_part(part)
         payload_str = json.dumps(payload)
-        self.logger.debug('Executing POST for {}. Payload={}'.format(
-            part, payload_str))
+        self.logger.debug(
+            'Executing POST for %s. Payload=%s', part, payload_str)
         resp = self.con.post(
             '{}{}'.format(self.base_uri, part),
             data=payload_str, *args, **kwargs)
-        self.logger.debug('Response for {}. Status: {}'.format(
-            part, resp.status_code))
+        self.logger.debug(
+            'Response for %s. Status: %s', part, resp.status_code)
         return resp
 
     def register_node(self, name):

--- a/src/commissaire/containermgr/trivial.py
+++ b/src/commissaire/containermgr/trivial.py
@@ -61,7 +61,7 @@ class TrivialContainerManager(ContainerManagerBase):  # pragma: no cover
         """
         # This method is idempotent.
         self.nodes.add(address)
-        self.logger.debug('Registered node {}'.format(address))
+        self.logger.debug('Registered node %s', address)
 
     def remove_node(self, address):
         """
@@ -74,7 +74,7 @@ class TrivialContainerManager(ContainerManagerBase):  # pragma: no cover
         """
         # This method is idempotent.
         self.nodes.discard(address)
-        self.logger.debug('Removed node {}'.format(address))
+        self.logger.debug('Removed node %s', address)
 
     def remove_all_nodes(self):
         """
@@ -101,7 +101,7 @@ class TrivialContainerManager(ContainerManagerBase):  # pragma: no cover
         """
         if address in self.nodes:
             status = {'node': address, 'status': 'ok'}
-            self.logger.debug('Node status: {}'.format(status))
+            self.logger.debug('Node status: %s', status)
             return status
         else:
             message = 'Node {} is not registered'.format(address)

--- a/src/commissaire/storage/client.py
+++ b/src/commissaire/storage/client.py
@@ -54,10 +54,11 @@ class StorageClient:
             return model_instance.__class__.new(**response['result'])
         except RemoteProcedureCallError as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to get {} "{}": {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_instance.__class__.__name__,
-                    model_instance.primary_key, error))
+                '%s: Unable to get %s "%s": %s',
+                self.bus_mixin.__class__.__name__,
+                model_instance.__class__.__name__,
+                model_instance.primary_key,
+                error)
             raise error
 
     def get_many(self, list_of_model_instances):
@@ -89,9 +90,10 @@ class StorageClient:
             return [model_class.new(**x) for x in response['result']]
         except RemoteProcedureCallError as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to get multiple {} records: {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_class.__name__, error))
+                '%s: Unable to get multiple %s records: %s',
+                self.bus_mixin.__class__.__name__,
+                model_class.__name__,
+                error)
             raise error
 
     def save(self, model_instance):
@@ -118,10 +120,11 @@ class StorageClient:
             return model_instance.__class__.new(**response['result'])
         except (RemoteProcedureCallError, models.ValidationError) as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to save {} "{}": {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_instance.__class__.__name__,
-                    model_instance.primary_key, error))
+                '%s: Unable to save %s "%s": %s',
+                self.bus_mixin.__class__.__name__,
+                model_instance.__class__.__name__,
+                model_instance.primary_key,
+                error)
             raise error
 
     def save_many(self, list_of_model_instances):
@@ -156,9 +159,10 @@ class StorageClient:
             return [model_class.new(**x) for x in response['result']]
         except (RemoteProcedureCallError, models.ValidationError) as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to save multiple {} records: {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_class.__name__, error))
+                '%s: Unable to save multiple %s records: %s',
+                self.bus_mixin.__class__.__name__,
+                model_class.__name__,
+                error)
             raise error
 
     def delete(self, model_instance):
@@ -178,10 +182,11 @@ class StorageClient:
             self.bus_mixin.request('storage.delete', params=params)
         except RemoteProcedureCallError as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to delete {} "{}": {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_instance.__class__.__name__,
-                    model_instance.primary_key, error))
+                '%s: Unable to delete %s "%s": %s',
+                self.bus_mixin.__class__.__name__,
+                model_instance.__class__.__name__,
+                model_instance.primary_key,
+                error)
             raise error
 
     def delete_many(self, list_of_model_instances):
@@ -210,9 +215,10 @@ class StorageClient:
             self.bus_mixin.request('storage.delete', params=params)
         except RemoteProcedureCallError as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to delete multiple {} records: {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_class.__name__, error))
+                '%s: Unable to delete multiple %s records: %s',
+                self.bus_mixin.__class__.__name__,
+                model_class.__name__,
+                error)
             raise error
 
     def list(self, model_class):
@@ -244,9 +250,10 @@ class StorageClient:
             return model_instance
         except (RemoteProcedureCallError, models.ValidationError) as error:
             self.bus_mixin.logger.error(
-                '{}: Unable to list {}s: {}'.format(
-                    self.bus_mixin.__class__.__name__,
-                    model_class.__name__, error))
+                '%s: Unable to list %ss: %s',
+                self.bus_mixin.__class__.__name__,
+                model_class.__name__,
+                error)
             raise error
 
     # -----------------------------------------------------------------------

--- a/src/commissaire/storage/etcd.py
+++ b/src/commissaire/storage/etcd.py
@@ -173,7 +173,7 @@ class EtcdStoreHandler(StoreHandlerBase):
                 #      possible that bad data could trigger a response.
                 self.logger.warn(
                     'Etcd returned unserializable data. Skipping the record.'
-                    'TypeError: {}'.format(error))
+                    'TypeError: %s', error)
 
         # Fill the list container with the results and return the model.
         setattr(model_instance, model_instance._list_attr, results)

--- a/src/commissaire/util/ssh.py
+++ b/src/commissaire/util/ssh.py
@@ -47,12 +47,12 @@ class TemporarySSHKey:
         with tempfile.NamedTemporaryFile(prefix='key', delete=False) as f:
             self.path = f.name
             self.logger.debug(
-                'Using {} as the temporary key location for {}'.format(
-                    self.path, self._host.address))
+                'Using %s as the temporary key location for %s',
+                self.path, self._host.address)
             input_bytes = bytes(self._host.ssh_priv_key, 'utf8')
             f.write(base64.decodestring(input_bytes))
             f.flush()
-            self.logger.info('Wrote key for {}'.format(self._host.address))
+            self.logger.info('Wrote key for %s', self._host.address)
 
     def remove(self):
         """
@@ -61,12 +61,12 @@ class TemporarySSHKey:
         try:
             os.unlink(self.path)
             self.logger.debug(
-                'Removed temporary key file {}'.format(self.path))
+                'Removed temporary key file %s', self.path)
         except:
             exc_type, exc_msg, tb = sys.exc_info()
             self.logger.warn(
                 'Unable to remove the temporary key file: '
-                '{}. Exception:{}'.format(self.path, exc_msg))
+                '%s. Exception: %s', self.path, exc_msg)
 
     def __enter__(self):
         """

--- a/test/test_util_ssh.py
+++ b/test/test_util_ssh.py
@@ -82,6 +82,7 @@ class Test_TemporarySSHKey(TestCase):
             key.remove()
             self.assertTrue(os.path.isfile(key.path))
             # We should have a warning in the log
-            mock_logger.warn.assert_called_once_with(mock.ANY)
+            mock_logger.warn.assert_called_once_with(
+                mock.ANY, mock.ANY, mock.ANY)
         # Clean up the file
         key.remove()


### PR DESCRIPTION
Logging can only do lazy formatting when % style strings are used. By
switching just these log lines over to the % style we avoid the (small)
overhead of formatting strings that would never be used.