### PR TITLE
Fix link to DEVEL instructions in RTD sources.

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -8,7 +8,7 @@ https://github.com/projectatomic/commissaire.
 
 Development Setup
 -----------------
-See `DEVEL.rst <https://github.com/projectatomic/commissaire-http/blob/master/DEVEL.rst>`_
+See `DEVEL.rst <https://github.com/projectatomic/commissaire/blob/master/DEVEL.rst>`_
 
 Vagrant
 -------


### PR DESCRIPTION
Devel link was broken.

Fixes #123 